### PR TITLE
Exclude UTC flag if timezone support is enabled

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -182,13 +182,13 @@ class Event extends Component
      */
     protected function getDateFormat($noTime = false)
     {
-		// Do not use UTC time (Z) if timezone support is enabled.
-		if ($this->useTimezone) {
-			return $noTime ? 'Ymd' : 'Ymd\THis';
-		}
-		else {
-			return $noTime ? 'Ymd' : 'Ymd\THis\Z';
-		}
+        // Do not use UTC time (Z) if timezone support is enabled.
+        if ($this->useTimezone) {
+            return $noTime ? 'Ymd' : 'Ymd\THis';
+        }
+        else {
+            return $noTime ? 'Ymd' : 'Ymd\THis\Z';
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed that the UTC Z flag is still appended to the event times even when time zone support is enabled. Apple iCal (5.0.3 on OS X 10.7.5) and Microsoft Outlook 2010 disregard the timezone and instead display the times in UTC format. Google Calendar does appear to respect the timezone. I modified the `getDateFormat()` function to generate a local or UTC time format.

Generated .ics file with UTC times:

``` text
BEGIN:VCALENDAR
VERSION:2.0
PRODID:example.com
BEGIN:VEVENT
UID:517e9487dca43
DTSTAMP:20130429T114055Z
DTSTART:20130530T193000Z
SEQUENCE:0
TRANSP:OPAQUE
DTEND:20130530T213000Z
SUMMARY:My Event
END:VEVENT
END:VCALENDAR
```

And without:

``` text
BEGIN:VCALENDAR
VERSION:2.0
PRODID:example.com
BEGIN:VEVENT
UID:517e9329e09df
DTSTAMP;TZID=America/New_York:20130429T113505
DTSTART;TZID=America/New_York:20130530T193000
SEQUENCE:0
TRANSP:OPAQUE
DTEND;TZID=America/New_York:20130530T213000
SUMMARY:My Event
END:VEVENT
END:VCALENDAR
```
