### PR TITLE
An event does not need to have a DTEND/DURATION element

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -182,7 +182,7 @@ class Event extends Component
         // An event can have a 'dtend' or 'duration', but not both.
         if (null != $this->dtEnd) {
             $this->properties->add($this->buildDateTimeProperty('DTEND', $this->dtEnd, $this->noTime));
-        } else {
+        } elseif (null != $this->duration) {
             $this->properties->set('DURATION', $this->duration->format('P%dDT%hH%iM%sS'));
         }
 


### PR DESCRIPTION
From what I can tell, a VEVENT does not need a DTEND nor a DURATION element.  However, failing to specify one with your library results in a PHP error.

I've done my best to maintain your code style.  All tests continue to pass.
