### PR TITLE
Dates with utc value

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -217,13 +217,19 @@ class Event extends Component
         if (null != $this->location) {
             $this->properties->set('LOCATION', $this->location);
 
-            if(null != $this->locationGeo) {
-                $this->properties->add(new Property('X-APPLE-STRUCTURED-LOCATION', 'geo:'.$this->locationGeo, array(
-                    'VALUE' => 'URI',
-                    'X-ADDRESS' => $this->location,
-                    'X-APPLE-RADIUS' => 49,
-                    'X-TITLE' => $this->locationTitle,
-                )));
+            if (null != $this->locationGeo) {
+                $this->properties->add(
+                    new Property(
+                        'X-APPLE-STRUCTURED-LOCATION',
+                        'geo:' . $this->locationGeo,
+                        array(
+                            'VALUE'          => 'URI',
+                            'X-ADDRESS'      => $this->location,
+                            'X-APPLE-RADIUS' => 49,
+                            'X-TITLE'        => $this->locationTitle,
+                        )
+                    )
+                );
             }
         }
 
@@ -251,7 +257,7 @@ class Event extends Component
             $this->properties->set('ORGANIZER', $this->organizer);
         }
 
-        if( $this->noTime ) {
+        if ($this->noTime) {
             $this->properties->set('X-MICROSOFT-CDO-ALLDAYEVENT', 'TRUE');
         }
 
@@ -267,11 +273,11 @@ class Event extends Component
             $this->buildDateTimeProperty('DTSTAMP', $this->dtStamp ?: new \DateTime())
         );
 
-        if( $this->created ) {
+        if ($this->created) {
             $this->properties->add($this->buildDateTimeProperty('CREATED', $this->created));
         }
 
-        if( $this->modified ) {
+        if ($this->modified) {
             $this->properties->add($this->buildDateTimeProperty('LAST-MODIFIED', $this->modified));
         }
 
@@ -283,9 +289,10 @@ class Event extends Component
     /**
      * Creates a Property based on a DateTime object
      *
-     * @param  string                $name     The name of the Property
-     * @param  \DateTime             $dateTime The DateTime
-     * @param  bool                  $noTime   Indicates if the time will be added
+     * @param  string    $name     The name of the Property
+     * @param  \DateTime $dateTime The DateTime
+     * @param  bool      $noTime   Indicates if the time will be added
+     *
      * @return \Eluceo\iCal\Property
      */
     protected function buildDateTimeProperty($name, \DateTime $dateTime, $noTime = false)
@@ -298,7 +305,7 @@ class Event extends Component
             $params['TZID'] = $timeZone;
         }
 
-        if($noTime) {
+        if ($noTime) {
             $params['VALUE'] = 'DATE';
         }
 
@@ -308,7 +315,8 @@ class Event extends Component
     /**
      * Returns the date format that can be passed to DateTime::format()
      *
-     * @param  bool   $noTime Indicates if the time will be added
+     * @param  bool $noTime Indicates if the time will be added
+     *
      * @return string
      */
     protected function getDateFormat($noTime = false)
@@ -326,6 +334,7 @@ class Event extends Component
      *
      * @param  \DateTime|null $dateTime The DateTime object
      * @param  bool           $noTime   Indicates if the time will be added
+     *
      * @return mixed
      */
     protected function getDateString(\DateTime $dateTime = null, $noTime = false)
@@ -339,6 +348,7 @@ class Event extends Component
 
     /**
      * @param $dtEnd
+     *
      * @return $this
      */
     public function setDtEnd($dtEnd)
@@ -360,6 +370,7 @@ class Event extends Component
 
     /**
      * @param $dtStamp
+     *
      * @return $this
      */
     public function setDtStamp($dtStamp)
@@ -370,6 +381,7 @@ class Event extends Component
 
     /**
      * @param $duration
+     *
      * @return $this
      */
     public function setDuration($duration)
@@ -379,21 +391,23 @@ class Event extends Component
     }
 
     /**
-     * @param $location
+     * @param        $location
      * @param string $title
-     * @param null $geo
+     * @param null   $geo
+     *
      * @return $this
      */
     public function setLocation($location, $title = '', $geo = null)
     {
-        $this->location = $location;
+        $this->location      = $location;
         $this->locationTitle = $title;
-        $this->locationGeo = $geo;
+        $this->locationGeo   = $geo;
         return $this;
     }
 
     /**
      * @param $noTime
+     *
      * @return $this
      */
     public function setNoTime($noTime)
@@ -404,6 +418,7 @@ class Event extends Component
 
     /**
      * @param $sequence
+     *
      * @return $this
      */
     public function setSequence($sequence)
@@ -414,6 +429,7 @@ class Event extends Component
 
     /**
      * @param $organizer
+     *
      * @return $this
      */
     public function setOrganizer($organizer)
@@ -424,6 +440,7 @@ class Event extends Component
 
     /**
      * @param $summary
+     *
      * @return $this
      */
     public function setSummary($summary)
@@ -434,6 +451,7 @@ class Event extends Component
 
     /**
      * @param $uniqueId
+     *
      * @return $this
      */
     public function setUniqueId($uniqueId)
@@ -444,6 +462,7 @@ class Event extends Component
 
     /**
      * @param $url
+     *
      * @return $this
      */
     public function setUrl($url)
@@ -454,6 +473,7 @@ class Event extends Component
 
     /**
      * @param $useTimezone
+     *
      * @return $this
      */
     public function setUseTimezone($useTimezone)
@@ -472,6 +492,7 @@ class Event extends Component
 
     /**
      * @param $attendees
+     *
      * @return $this
      */
     public function setAttendees($attendees)
@@ -482,6 +503,8 @@ class Event extends Component
 
     /**
      * @param string $attendee
+     * @param array  $params
+     *
      * @return $this
      */
     public function addAttendee($attendee, $params = array())
@@ -503,6 +526,7 @@ class Event extends Component
 
     /**
      * @param $description
+     *
      * @return $this
      */
     public function setDescription($description)
@@ -513,6 +537,7 @@ class Event extends Component
 
     /**
      * @param bool $useUtc
+     *
      * @return $this
      */
     public function setUseUtc($useUtc = true)
@@ -531,24 +556,27 @@ class Event extends Component
 
     /**
      * @param $status
+     *
      * @return $this
      */
     public function setCancelled($status)
     {
-        $this->cancelled = (bool) $status;
+        $this->cancelled = (bool)$status;
         return $this;
     }
 
     /**
      * @param $transparency
+     *
      * @return $this
      * @throws \InvalidArgumentException
      */
     public function setTimeTransparency($transparency)
     {
         $transparency = strtoupper($transparency);
-        if ($transparency === self::TIME_TRANSPARENCY_OPAQUE ||
-            $transparency === self::TIME_TRANSPARENCY_TRANSPARENT) {
+        if ($transparency === self::TIME_TRANSPARENCY_OPAQUE
+            || $transparency === self::TIME_TRANSPARENCY_TRANSPARENT
+        ) {
             $this->transparency = $transparency;
         } else {
             throw new InvalidArgumentException('Invalid value for transparancy');
@@ -558,15 +586,17 @@ class Event extends Component
 
     /**
      * @param $status
+     *
      * @return $this
      * @throws \InvalidArgumentException
      */
     public function setStatus($status)
     {
         $status = strtoupper($status);
-        if ($status == self::STATUS_CANCELLED ||
-            $status == self::STATUS_CONFIRMED ||
-            $status == self::STATUS_TENTATIVE) {
+        if ($status == self::STATUS_CANCELLED
+            || $status == self::STATUS_CONFIRMED
+            || $status == self::STATUS_TENTATIVE
+        ) {
             $this->status = $status;
         } else {
             throw new InvalidArgumentException('Invalid value for status');
@@ -576,6 +606,7 @@ class Event extends Component
 
     /**
      * @param RecurrenceRule $recurrenceRule
+     *
      * @return $this
      */
     public function setRecurrenceRule(RecurrenceRule $recurrenceRule)
@@ -594,6 +625,7 @@ class Event extends Component
 
     /**
      * @param $dtStamp
+     *
      * @return $this
      */
     public function setCreated($dtStamp)
@@ -604,6 +636,7 @@ class Event extends Component
 
     /**
      * @param $dtStamp
+     *
      * @return $this
      */
     public function setModified($dtStamp)


### PR DESCRIPTION
Hi,

this pull request is related to date values which have to be set in UTC ...
- `DTSTAMP`
- `CREATED`
- `LAST-MODIFIED`

We do respect that now by enforcing proper `Event` attribute values (`useUTC` & `useTimezone`) while generating the date values.
