### PR TITLE
Fix issues brought by last commit

### DIFF
--- a/src/Eluceo/iCal/Component/TimezoneRule.php
+++ b/src/Eluceo/iCal/Component/TimezoneRule.php
@@ -78,23 +78,23 @@ class TimezoneRule extends Component
     {
         $propertyBag = new PropertyBag();
 
-        if (null !== $this->getTzName()) {
+        if ($this->getTzName()) {
             $propertyBag->set('TZNAME', $this->getTzName());
         }
 
-        if (null !== $this->getTzOffsetFrom()) {
+        if ($this->getTzOffsetFrom()) {
             $propertyBag->set('TZOFFSETFROM', $this->getTzOffsetFrom());
         }
 
-        if (null !== $this->getTzOffsetTo()) {
+        if ($this->getTzOffsetTo()) {
             $propertyBag->set('TZOFFSETTO', $this->getTzOffsetTo());
         }
 
-        if (null !== $this->getDtStart()) {
+        if ($this->getDtStart()) {
             $propertyBag->set('DTSTART', $this->getDtStart());
         }
 
-        if (null !== $this->recurrenceRule) {
+        if ($this->recurrenceRule) {
             $propertyBag->set('RRULE', $this->recurrenceRule);
         }
 

--- a/src/Eluceo/iCal/Component/TimezoneRule.php
+++ b/src/Eluceo/iCal/Component/TimezoneRule.php
@@ -210,6 +210,6 @@ class TimezoneRule extends Component
             return $this->dtStart->format('Ymd\THis');
         }
 
-        return nulll;
+        return null;
     }
 }


### PR DESCRIPTION
- Fixes the typo in `nulll`
- Removes the unnecessary typehint condition (or should we add the specific `null !==` condition only when the property value could be evaluated to `null`?)