### PR TITLE
Allow new lines in event descriptions

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -17,6 +17,7 @@ use Eluceo\iCal\Property\DateTimeProperty;
 use Eluceo\iCal\Property\Event\Attendees;
 use Eluceo\iCal\Property\Event\Organizer;
 use Eluceo\iCal\Property\Event\RecurrenceRule;
+use Eluceo\iCal\Property\Event\Description;
 use Eluceo\iCal\PropertyBag;
 
 /**
@@ -264,7 +265,7 @@ class Event extends Component
         $propertyBag->set('CLASS', $this->isPrivate ? 'PRIVATE' : 'PUBLIC');
 
         if (null != $this->description) {
-            $propertyBag->set('DESCRIPTION', $this->description);
+            $propertyBag->set('DESCRIPTION', new Description($this->description));
         }
 
         if (null != $this->recurrenceRule) {

--- a/src/Eluceo/iCal/Property/Event/Description.php
+++ b/src/Eluceo/iCal/Property/Event/Description.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Eluceo\iCal\Property\Event;
+
+use Eluceo\iCal\Property\ValueInterface;
+use Eluceo\iCal\Util\PropertyValueUtil;
+
+/**
+ * Class Description
+ * Alows new line charectars to be in the description
+ *
+ * @package Eluceo\iCal\Property
+ */
+class Description implements ValueInterface
+{
+    /**
+     * The value.
+     *
+     * @var string
+     */
+    protected $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Return the value of the Property as an escaped string.
+     *
+     * Escape values as per RFC 2445. See http://www.kanzaki.com/docs/ical/text.html
+     *
+     * @return string
+     */
+    public function getEscapedValue()
+    {
+        return PropertyValueUtil::escapeValueAllowNewLine((string) $this->value);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Eluceo/iCal/Util/PropertyValueUtil.php
+++ b/src/Eluceo/iCal/Util/PropertyValueUtil.php
@@ -6,11 +6,18 @@ class PropertyValueUtil
 {
     public static function escapeValue($value)
     {
+        $value = self::escapeValueAllowNewLine($value);
+        $value = str_replace("\n", '\\n', $value);
+
+        return $value;
+    }
+
+    public static function escapeValueAllowNewLine($value)
+    {
         $value = str_replace('\\', '\\\\', $value);
         $value = str_replace('"', '\\"', $value);
         $value = str_replace(',', '\\,', $value);
         $value = str_replace(';', '\\;', $value);
-        $value = str_replace("\n", '\\n', $value);
         $value = str_replace(
             array(
                 "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07",

--- a/tests/Eluceo/iCal/ComponentTest.php
+++ b/tests/Eluceo/iCal/ComponentTest.php
@@ -26,4 +26,20 @@ class ComponentTest extends \PHPUnit_Framework_TestCase
         $output = preg_replace('/\r\n /u', '', $output);
         $this->assertContains($input, $output);
     }
+
+    public function testDescriptionWithNewLines()
+    {
+        $input = "new string \n new line \n new line \n new string";
+
+        $vCalendar = new \Eluceo\iCal\Component\Calendar('www.example.com');
+        $vEvent    = new \Eluceo\iCal\Component\Event();
+        $vEvent->setDtStart(new \DateTime('2014-12-24'));
+        $vEvent->setDtEnd(new \DateTime('2014-12-24'));
+        $vEvent->setDescription($input);
+
+        $vCalendar->addComponent($vEvent);
+
+        $output = $vCalendar->render();
+        $this->assertContains($input, $output);
+    }
 }

--- a/tests/Eluceo/iCal/Property/Event/DescriptionTest.php
+++ b/tests/Eluceo/iCal/Property/Event/DescriptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Eluceo\iCal\Property\Event;
+
+class DescriptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAllowsNewLines()
+    {
+        $testString = "New String \n New Line";
+        $description = new Description($testString);
+
+        $this->assertEquals(
+            $testString,
+            $description->getEscapedValue()
+        );
+    }
+}


### PR DESCRIPTION
I'm pretty sure that description is allowed to contain new lines:
https://tools.ietf.org/html/rfc5545#page-85

I took at pass at implementing this, but I'm happy to do it a different way.