### PR TITLE
Use 'escapeValue' to escape the new line character

### DIFF
--- a/src/Eluceo/iCal/Property/Event/Description.php
+++ b/src/Eluceo/iCal/Property/Event/Description.php
@@ -34,7 +34,7 @@ class Description implements ValueInterface
      */
     public function getEscapedValue()
     {
-        return PropertyValueUtil::escapeValueAllowNewLine((string) $this->value);
+        return PropertyValueUtil::escapeValue((string) $this->value);
     }
 
     /**

--- a/tests/Eluceo/iCal/ComponentTest.php
+++ b/tests/Eluceo/iCal/ComponentTest.php
@@ -40,6 +40,6 @@ class ComponentTest extends \PHPUnit_Framework_TestCase
         $vCalendar->addComponent($vEvent);
 
         $output = $vCalendar->render();
-        $this->assertContains($input, $output);
+        $this->assertContains(str_replace("\n", "\\n", $input), $output);
     }
 }

--- a/tests/Eluceo/iCal/Property/Event/DescriptionTest.php
+++ b/tests/Eluceo/iCal/Property/Event/DescriptionTest.php
@@ -10,7 +10,7 @@ class DescriptionTest extends \PHPUnit_Framework_TestCase
         $description = new Description($testString);
 
         $this->assertEquals(
-            $testString,
+            str_replace("\n", "\\n", $testString),
             $description->getEscapedValue()
         );
     }


### PR DESCRIPTION
We need to escape the new line character as well as per RFC:
http://tools.ietf.org/html/rfc5545#section-3.3.11
