### PR TITLE
Add geographic position property to event

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -21,6 +21,7 @@ use Eluceo\iCal\Property\Event\Description;
 use Eluceo\iCal\PropertyBag;
 use Eluceo\iCal\Property\Event\RecurrenceId;
 use Eluceo\iCal\Property\DateTimesProperty;
+use Eluceo\iCal\Property\GeoValue;
 
 /**
  * Implementation of the EVENT component.
@@ -274,7 +275,7 @@ class Event extends Component
         }
 
         if (null != $this->locationGeo) {
-            $propertyBag->set('GEO', $this->locationGeo);
+            $propertyBag->set('GEO', new GeoValue($this->locationGeo));
         }
 
         if (null != $this->summary) {

--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -273,6 +273,10 @@ class Event extends Component
             }
         }
 
+        if (null != $this->locationGeo) {
+            $propertyBag->set('GEO', $this->locationGeo);
+        }
+
         if (null != $this->summary) {
             $propertyBag->set('SUMMARY', $this->summary);
         }

--- a/src/Eluceo/iCal/Property/GeoValue.php
+++ b/src/Eluceo/iCal/Property/GeoValue.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Eluceo\iCal\Property;
+
+class GeoValue implements ValueInterface
+{
+    /**
+     * The value.
+     *
+     * @var string
+     */
+    protected $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEscapedValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
I know that you already have geolocation in event with X-APPLE-STRUCTURED-LOCATION, however this does not work with non-apple devices. This commit simply adds RFC compliant property GEO to event(see [RFC 5545](https://tools.ietf.org/html/rfc5545#section-3.8.1.6))