### PR TITLE
Fix for UID not unique with uniqid()

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -210,7 +210,7 @@ class Event extends Component
     public function __construct($uniqueId = null)
     {
         if (null == $uniqueId) {
-            $uniqueId = uniqid();
+            $uniqueId = uniqid('', true);
         }
 
         $this->uniqueId = $uniqueId;


### PR DESCRIPTION
on my windows php, the generated events in the ical file all have the same UID.

maybe it has something to do with this:
> Under Cygwin, the more_entropy must be set to TRUE for this function to work. 
https://secure.php.net/manual/en/function.uniqid.php

the rfc5545 also shows more complex UID examples, maybe the complete UID generation should be refactored:
> `UID:20070313T123432Z-456553@example.com`

```
3.8.4.7.  Unique Identifier

   Property Name:  UID

   Purpose:  This property defines the persistent, globally unique
      identifier for the calendar component.

   Value Type:  TEXT

   Property Parameters:  IANA and non-standard property parameters can
      be specified on this property.

   Conformance:  The property MUST be specified in the "VEVENT",
      "VTODO", "VJOURNAL", or "VFREEBUSY" calendar components.

   Description:  The "UID" itself MUST be a globally unique identifier.
      The generator of the identifier MUST guarantee that the identifier
      is unique.  There are several algorithms that can be used to
      accomplish this.  A good method to assure uniqueness is to put the
      domain name or a domain literal IP address of the host on which
      the identifier was created on the right-hand side of an "@", and
      on the left-hand side, put a combination of the current calendar
      date and time of day (i.e., formatted in as a DATE-TIME value)
      along with some other currently unique (perhaps sequential)
      identifier available on the system (for example, a process id
      number).  Using a DATE-TIME value on the left-hand side and a
      domain name or domain literal on the right-hand side makes it
      possible to guarantee uniqueness since no two hosts should be
      using the same domain name or IP address at the same time.  Though
      other algorithms will work, it is RECOMMENDED that the right-hand
      side contain some domain identifier (either of the host itself or
      otherwise) such that the generator of the message identifier can
      guarantee the uniqueness of the left-hand side within the scope of
      that domain.
```
https://www.ietf.org/rfc/rfc5545.txt