### PR TITLE
make GEO property RFC 5545 compliant

### DIFF
--- a/src/Eluceo/iCal/Component/Event.php
+++ b/src/Eluceo/iCal/Component/Event.php
@@ -197,7 +197,7 @@ class Event extends Component
 
     /**
      * Dates to be excluded from a series of events.
-     * 
+     *
      * @var \DateTime[]
      */
     protected $exDates = array();
@@ -270,7 +270,7 @@ class Event extends Component
                         )
                     )
                 );
-                $propertyBag->set('GEO', $this->locationGeo);
+                $propertyBag->set('GEO', str_replace(',', ';', $this->locationGeo));
             }
         }
 


### PR DESCRIPTION
this should fix issue #73 for Google Calendar as it changes the `GEO ` property to be RFC 5545 compliant.

This is a very naive fix but it's the easiest solution without requiring more changes.