### PR TITLE
Check if $geo is null before evaluating

### DIFF
--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -432,7 +432,7 @@ class Event extends Component
     {
         if (is_scalar($geo)) {
             $geo = Geo::fromString($geo);
-        } elseif (!$geo instanceof Geo) {
+        } elseif (!is_null($geo) && !$geo instanceof Geo) {
             $className = get_class($geo);
             throw new \InvalidArgumentException(
                 "The parameter 'geo' must be a string or an instance of " . Geo::class


### PR DESCRIPTION
Otherwise $geo becomes defacto required by setLocation.

To make matters more interesting PHP < 7 evaluates `get_class(null)` as the current class name so the error when null is passed says:

The parameter 'geo' must be a string or an instance of \Eluceo\iCal\Property\Event\Geo but an instance of Eluceo\iCal\Component\Event was given
