### PR TITLE
Add support for DateTimeImmutable in buildPropertyBag

### DIFF
--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -258,10 +258,11 @@ class Event extends Component
 
         // An event can have a 'dtend' or 'duration', but not both.
         if ($this->dtEnd !== null) {
+            $dtEnd = clone $this->dtEnd;
             if ($this->noTime === true) {
-                $this->dtEnd = $this->dtEnd->add(new \DateInterval('P1D'));
+                $dtEnd = $dtEnd->add(new \DateInterval('P1D'));
             }
-            $propertyBag->add(new DateTimeProperty('DTEND', $this->dtEnd, $this->noTime, $this->useTimezone, $this->useUtc, $this->timezoneString));
+            $propertyBag->add(new DateTimeProperty('DTEND', $dtEnd, $this->noTime, $this->useTimezone, $this->useUtc, $this->timezoneString));
         } elseif ($this->duration !== null) {
             $propertyBag->set('DURATION', $this->duration->format('P%dDT%hH%iM%sS'));
         }

--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -259,7 +259,7 @@ class Event extends Component
         // An event can have a 'dtend' or 'duration', but not both.
         if ($this->dtEnd !== null) {
             if ($this->noTime === true) {
-                $this->dtEnd->add(new \DateInterval('P1D'));
+                $this->dtEnd = $this->dtEnd->add(new \DateInterval('P1D'));
             }
             $propertyBag->add(new DateTimeProperty('DTEND', $this->dtEnd, $this->noTime, $this->useTimezone, $this->useUtc, $this->timezoneString));
         } elseif ($this->duration !== null) {

--- a/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
+++ b/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
@@ -119,4 +119,26 @@ class CalendarIntegrationTest extends TestCase
             $this->assertRegExp($lines[$key], $line);
         }
     }
+
+    /**
+     * This test was introduced because of a regression bug.
+     *
+     * @see https://github.com/markuspoerschke/iCal/issues/98
+     *
+     * @coversNothing
+     */
+    public function testRenderIsIdempotent()
+    {
+        $vCalendar = new \Eluceo\iCal\Component\Calendar('www.example.com');
+
+        $vEvent = new \Eluceo\iCal\Component\Event('123456');
+        $vEvent->setDtStart(new \DateTime('2012-12-24'));
+        $vEvent->setDtEnd(new \DateTime('2012-01-04'));
+        $vEvent->setNoTime(true);
+        $vEvent->setSummary('Vacations');
+
+        $vCalendar->addComponent($vEvent);
+
+        $this->assertEquals($vCalendar->render(), $vCalendar->render());
+    }
 }


### PR DESCRIPTION
If `dtEnd` were to be a DateTimeImmutable instead of a DateTime, the add method would have no effect on the outcome.

Here, we update the stored dtEnd with the result of the add method.  For a DateTime object, this will be the same object - for a DateTimeImmutable object, this will be a new DateTimeImmutable one day in the future.