### PR TITLE
Optimize Performance for long lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     "require": {
         "php": ">=7.0"
     },
+    "suggest": {
+        "ext-mbstring" : "Massive performance enhancement of line folding"
+    },
     "require-dev": {
         "phpunit/phpunit": "^6.0"
     },

--- a/src/Util/ComponentUtil.php
+++ b/src/Util/ComponentUtil.php
@@ -30,7 +30,7 @@ class ComponentUtil
         $lines = [];
         while (strlen($string) > 0) {
             if (strlen($string) > 75) {
-                $lines[] = mb_strcut($string, 0, 75, 'utf-8') . "\r\n";
+                $lines[] = mb_strcut($string, 0, 75, 'utf-8');
                 $string = ' ' . mb_strcut($string, 75, strlen($string), 'utf-8');
             } else {
                 $lines[] = $string;

--- a/src/Util/ComponentUtil.php
+++ b/src/Util/ComponentUtil.php
@@ -31,10 +31,10 @@ class ComponentUtil
         while (strlen($string) > 0) {
             if (strlen($string) > 75) {
                 $lines[] = mb_strcut($string, 0, 75, 'utf-8') . "\r\n";
-                $str = ' ' . mb_strcut($string, 75, strlen($string), 'utf-8');
+                $string = ' ' . mb_strcut($string, 75, strlen($string), 'utf-8');
             } else {
                 $lines[] = $string;
-                $str = '';
+                $string = '';
                 break;
             }
         }

--- a/src/Util/ComponentUtil.php
+++ b/src/Util/ComponentUtil.php
@@ -28,22 +28,16 @@ class ComponentUtil
     public static function fold($string)
     {
         $lines = [];
-        $array = preg_split('/(?<!^)(?!$)/u', $string);
-
-        $line = '';
-        $lineNo = 0;
-        foreach ($array as $char) {
-            $charLen = strlen($char);
-            $lineLen = strlen($line);
-            if ($lineLen + $charLen > 75) {
-                $line = ' ' . $char;
-                ++$lineNo;
+        while (strlen($string) > 0) {
+            if (strlen($string) > 75) {
+                $lines[] = mb_strcut($string, 0, 75, 'utf-8') . "\r\n";
+                $str = ' ' . mb_strcut($string, 75, strlen($string), 'utf-8');
             } else {
-                $line .= $char;
+                $lines[] = $string;
+                $str = '';
+                break;
             }
-            $lines[$lineNo] = $line;
         }
-
         return $lines;
     }
 }

--- a/src/Util/ComponentUtil.php
+++ b/src/Util/ComponentUtil.php
@@ -21,23 +21,42 @@ class ComponentUtil
      * @see https://tools.ietf.org/html/rfc5545#section-5
      * @see https://tools.ietf.org/html/rfc5545#section-3.1
      *
-     * @param $string
+     * @param string $string
      *
      * @return array
      */
     public static function fold($string)
     {
-        $lines = [];
-        while (strlen($string) > 0) {
-            if (strlen($string) > 75) {
-                $lines[] = mb_strcut($string, 0, 75, 'utf-8');
-                $string = ' ' . mb_strcut($string, 75, strlen($string), 'utf-8');
-            } else {
-                $lines[] = $string;
-                $string = '';
-                break;
+        $lines = array();
+
+        if (function_exists('mb_strcut')) {
+            while (strlen($string) > 0) {
+                if (strlen($string) > 75) {
+                    $lines[] = mb_strcut($string, 0, 75, 'utf-8');
+                    $string = ' ' . mb_strcut($string, 75, strlen($string), 'utf-8');
+                } else {
+                    $lines[] = $string;
+                    $string = '';
+                    break;
+                }
+            }
+        } else {
+            $array = preg_split('/(?<!^)(?!$)/u', $string);
+            $line = '';
+            $lineNo = 0;
+            foreach ($array as $char) {
+                $charLen = strlen($char);
+                $lineLen = strlen($line);
+                if ($lineLen + $charLen > 75) {
+                    $line = ' ' . $char;
+                    ++$lineNo;
+                } else {
+                    $line .= $char;
+                }
+                $lines[$lineNo] = $line;
             }
         }
+
         return $lines;
     }
 }


### PR DESCRIPTION
use mb_strcut() instead of preg_split()