### PR TITLE
Convert times to UTC if in UTC mode

### DIFF
--- a/src/Util/DateUtil.php
+++ b/src/Util/DateUtil.php
@@ -45,6 +45,13 @@ class DateUtil
             $dateTime = new \DateTimeImmutable();
         }
 
+        // Only convert the DateTime to UTC if there is a time present. For date-only the
+        // timezone is meaningless and converting it might shift it to the wrong date.
+        if (!$noTime && $useUtc) {
+            $dateTime = clone $dateTime;
+            $dateTime->setTimezone(new \DateTimeZone('UTC'));
+        }
+
         return $dateTime->format(self::getDateFormat($noTime, $useTimezone, $useUtc));
     }
 

--- a/tests/Eluceo/iCal/Util/DateUtilTest.php
+++ b/tests/Eluceo/iCal/Util/DateUtilTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Eluceo\iCal\Property;
+
+use Eluceo\iCal\Util\DateUtil;
+use PHPUnit\Framework\TestCase;
+
+class DateUtilTest extends TestCase
+{
+    public function testTimeConvertsToUTC()
+    {
+        $dateTime   = new \DateTime('2000-01-01T00:00:00+1000');
+        $dateString = DateUtil::getDateString($dateTime, false, false, true);
+
+        $this->assertEquals('19991231T140000Z', $dateString);
+    }
+
+    public function testNoTimezoneConversionForDateOnly()
+    {
+        $dateTime   = new \DateTime('2000-01-01T00:00:00+1000');
+        $dateString = DateUtil::getDateString($dateTime, true, false, true);
+
+        $this->assertEquals('20000101', $dateString);
+    }
+
+    public function testNoTimezoneConversionWhenNotUsingUTC()
+    {
+        $dateTime   = new \DateTime('2000-01-01T00:00:00+1000');
+        $dateString = DateUtil::getDateString($dateTime, false, false, false);
+
+        $this->assertEquals('20000101T000000', $dateString);
+    }
+}


### PR DESCRIPTION
By default, event times are given in UTC with the `Z` suffix.

Unfortunately, the suffix is added statically without actually converting the time. So if the `DateTime` object is not already in the UTC timezone, a wrong date will appear in the output.

This PR adds the missing conversion.