### PR TITLE
DateUtil - only convert to UTC if no timezone is specified

### DIFF
--- a/src/Util/DateUtil.php
+++ b/src/Util/DateUtil.php
@@ -47,7 +47,8 @@ class DateUtil
 
         // Only convert the DateTime to UTC if there is a time present. For date-only the
         // timezone is meaningless and converting it might shift it to the wrong date.
-        if (!$noTime && $useUtc) {
+        // Do not convert DateTime to UTC if a timezone it specified, as it should be local time.
+        if (!$noTime && $useUtc && !$useTimezone) {
             $dateTime = clone $dateTime;
             $dateTime->setTimezone(new \DateTimeZone('UTC'));
         }


### PR DESCRIPTION
It should not convert to UTC if a timezone is specified, as it should use the local time from that timezone instead.

Can be read here - https://www.kanzaki.com/docs/ical/dateTime.html