### PR TITLE
Introduce Component::setComponents method

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -72,8 +72,8 @@ abstract class Component
     /**
      * Set all Components.
      *
-     * @param array $components The array of Component that will be set
-     * @param null  $key        The key of the Component
+     * @param Component[] $components The array of Component that will be set
+     * @param null        $key        The key of the Component
      */
     public function setComponents(array $components)
     {

--- a/src/Component.php
+++ b/src/Component.php
@@ -70,6 +70,19 @@ abstract class Component
     }
 
     /**
+     * Set all Components.
+     *
+     * @param array $components The array of Component that will be set
+     * @param null  $key        The key of the Component
+     */
+    public function setComponents(array $components)
+    {
+        $this->components = $components;
+
+        return $this;
+    }
+
+    /**
      * Renders an array containing the lines of the iCal file.
      *
      * @return array

--- a/tests/Eluceo/iCal/ComponentTest.php
+++ b/tests/Eluceo/iCal/ComponentTest.php
@@ -61,6 +61,29 @@ class ComponentTest extends TestCase
         $this->assertContains(str_replace("\n", "\\n", $input), $output);    
     }
 
+    public function testSetComponents()
+    {
+        $shouldNotBeFound = 'should-not-be-found';
+        $vCalendar = new \Eluceo\iCal\Component\Calendar('www.example.com');
+        $vEvent    = new \Eluceo\iCal\Component\Event();
+        $vEvent->setDtStart(new \DateTime('2014-12-24'));
+        $vEvent->setDtEnd(new \DateTime('2014-12-24'));
+        $vEvent->setDescription($shouldNotBeFound);
+        $vCalendar->addComponent($vEvent);
+
+        $shouldBeFound = 'this-should-be-found';
+        $vEventTwo = new \Eluceo\iCal\Component\Event();
+        $vEventTwo->setDtStart(new \DateTime('2015-12-24'));
+        $vEventTwo->setDtEnd(new \DateTime('2015-12-24'));
+        $vEventTwo->setDescription($shouldBeFound);
+
+        $vCalendar->setComponents([$vEventTwo]);
+
+        $output = $vCalendar->render();
+        $this->assertContains($shouldBeFound, $output);
+        $this->assertNotContains($shouldNotBeFound, $output);
+    }
+
     public function testToString()
     {
         $vCalendar = new \Eluceo\iCal\Component\Calendar('www.example.com');


### PR DESCRIPTION
I'm adding this method because I usually have an array of `Events` and I just want to pass them all to the calendar, without iterating over the list. It doesn't look like much but I think it keeps my code clearer.

In this method, we lose type safety, but I assume people know what they're doing.

```php
// before
foreach ($events as $event) {
    $calendar->addComponent($event);
}

// after
$calendar->setComponents($events);
```