### PR TITLE
RFC added ATTACH property refs: #71

### DIFF
--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -22,6 +22,7 @@ use Eluceo\iCal\Property\Event\RecurrenceId;
 use Eluceo\iCal\Property\Event\RecurrenceRule;
 use Eluceo\iCal\Property\RawStringValue;
 use Eluceo\iCal\PropertyBag;
+use Eluceo\iCal\Property\Event\Attachment;
 
 /**
  * Implementation of the EVENT component.
@@ -220,6 +221,11 @@ class Event extends Component
      */
     protected $recurrenceId;
 
+    /**
+     * @var Attachment[]
+     */
+    protected $attachments = [];
+
     public function __construct(string $uniqueId = null)
     {
         if (null == $uniqueId) {
@@ -364,6 +370,10 @@ class Event extends Component
 
         if ($this->modified) {
             $propertyBag->add(new DateTimeProperty('LAST-MODIFIED', $this->modified, false, false, true));
+        }
+
+        foreach ($this->attachments as $attachment) {
+            $propertyBag->add($attachment);
         }
 
         return $propertyBag;
@@ -876,5 +886,33 @@ class Event extends Component
         $this->recurrenceId = $recurrenceId;
 
         return $this;
+    }
+
+    /**
+     * @param array $attachment
+     *
+     * @return $this
+     */
+    public function addAttachment(Attachment $attachment)
+    {
+        $this->attachments[] = $attachment;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttachments()
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function addUrlAttachment(string $url)
+    {
+        $this->addAttachment(new Attachment($url));
     }
 }

--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -15,6 +15,7 @@ use Eluceo\iCal\Component;
 use Eluceo\iCal\Property;
 use Eluceo\iCal\Property\DateTimeProperty;
 use Eluceo\iCal\Property\DateTimesProperty;
+use Eluceo\iCal\Property\Event\Attachment;
 use Eluceo\iCal\Property\Event\Attendees;
 use Eluceo\iCal\Property\Event\Geo;
 use Eluceo\iCal\Property\Event\Organizer;
@@ -22,7 +23,6 @@ use Eluceo\iCal\Property\Event\RecurrenceId;
 use Eluceo\iCal\Property\Event\RecurrenceRule;
 use Eluceo\iCal\Property\RawStringValue;
 use Eluceo\iCal\PropertyBag;
-use Eluceo\iCal\Property\Event\Attachment;
 
 /**
  * Implementation of the EVENT component.

--- a/src/Property/Event/Attachment.php
+++ b/src/Property/Event/Attachment.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the eluceo/iCal package.
+ *
+ * (c) Markus Poerschke <markus@eluceo.de>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Eluceo\iCal\Property\Event;
+
+use Eluceo\iCal\Property;
+
+/**
+ * Class Attachment
+ * @package Eluceo\iCal\Property\Event
+ */
+class Attachment extends Property
+{
+    /**
+     * @param string $value
+     * @param array  $params
+     */
+    public function __construct($value, $params = [])
+    {
+        parent::__construct('ATTACH', $value, $params);
+    }
+
+    /**
+     * @param $url
+     * @throws \Exception
+     */
+    public function setUrl($url)
+    {
+        $this->setValue($url);
+    }
+}
+

--- a/src/Property/Event/Attachment.php
+++ b/src/Property/Event/Attachment.php
@@ -14,8 +14,7 @@ namespace Eluceo\iCal\Property\Event;
 use Eluceo\iCal\Property;
 
 /**
- * Class Attachment
- * @package Eluceo\iCal\Property\Event
+ * Class Attachment.
  */
 class Attachment extends Property
 {
@@ -30,6 +29,7 @@ class Attachment extends Property
 
     /**
      * @param $url
+     *
      * @throws \Exception
      */
     public function setUrl($url)
@@ -37,4 +37,3 @@ class Attachment extends Property
         $this->setValue($url);
     }
 }
-

--- a/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
+++ b/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
@@ -141,4 +141,45 @@ class CalendarIntegrationTest extends TestCase
 
         $this->assertEquals($vCalendar->render(), $vCalendar->render());
     }
+
+
+    /**
+     * This test was introduced because of the added ATTACH property to the Event class.
+     *
+     * @covers \Eluceo\iCal\Component\Event::addAttachment()
+     */
+    public function testEventAddAttachment()
+    {
+        $vCalendar = new \Eluceo\iCal\Component\Calendar('www.example.com');
+        $vEvent = new \Eluceo\iCal\Component\Event('123456');
+        $vEvent->setDtStart(new \DateTime('2012-12-24'));
+        $vEvent->setDtEnd(new \DateTime('2012-12-24'));
+        $vEvent->setSummary('Vacations');
+        $vEvent->addAttachment(new \Eluceo\iCal\Property\Event\Attachment('http://attach.example.com'));
+
+        $vCalendar->addComponent($vEvent);
+
+        $lines = array(
+            '/BEGIN:VCALENDAR/',
+            '/VERSION:2\.0/',
+            '/PRODID:www\.example\.com/',
+            '/BEGIN:VEVENT/',
+            '/UID:123456/',
+            '/DTSTART:20121223T230000Z/',
+            '/SEQUENCE:0/',
+            '/TRANSP:OPAQUE/',
+            '/DTEND:20121223T230000Z/',
+            '/SUMMARY:Vacations/',
+            '/CLASS:PUBLIC/',
+            '/DTSTAMP:20\d{6}T\d{6}Z/',
+            '/ATTACH:http:\/\/attach.example.com/',
+            '/END:VEVENT/',
+            '/END:VCALENDAR/',
+        );
+        foreach (explode("\n", $vCalendar->render()) as $key => $line)
+        {
+            $this->assertTrue(isset($lines[$key]), 'Too many lines... ' . $line);
+            $this->assertRegExp($lines[$key], $line);
+        }
+    }
 }

--- a/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
+++ b/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
@@ -142,43 +142,55 @@ class CalendarIntegrationTest extends TestCase
         $this->assertEquals($vCalendar->render(), $vCalendar->render());
     }
 
-
     /**
-     * This test was introduced because of the added ATTACH property to the Event class.
-     *
      * @covers \Eluceo\iCal\Component\Event::addAttachment()
      */
     public function testEventAddAttachment()
     {
+        $timeZone = new \DateTimeZone('Europe/Berlin');
+
+        // 1. Create new calendar
         $vCalendar = new \Eluceo\iCal\Component\Calendar('www.example.com');
+        $vCalendar->setPublishedTTL('P1W');
+
+        // 2. Create an event
         $vEvent = new \Eluceo\iCal\Component\Event('123456');
-        $vEvent->setDtStart(new \DateTime('2012-12-24'));
-        $vEvent->setDtEnd(new \DateTime('2012-12-24'));
-        $vEvent->setSummary('Vacations');
+        $vEvent->setDtStart(new \DateTime('2012-12-31', $timeZone));
+        $vEvent->setDtEnd(new \DateTime('2012-12-31', $timeZone));
+        $vEvent->setNoTime(true);
+        $vEvent->setIsPrivate(true);
+        $vEvent->setSummary('New Year’s Eve');
+
+        // 3. Add attachment
         $vEvent->addAttachment(new \Eluceo\iCal\Property\Event\Attachment('http://attach.example.com'));
 
+        // 4. Add event to calendar
         $vCalendar->addComponent($vEvent);
 
         $lines = array(
             '/BEGIN:VCALENDAR/',
             '/VERSION:2\.0/',
             '/PRODID:www\.example\.com/',
+            '/X-PUBLISHED-TTL:P1W/',
             '/BEGIN:VEVENT/',
             '/UID:123456/',
-            '/DTSTART:20121223T230000Z/',
+            '/DTSTART;VALUE=DATE:20121231/',
             '/SEQUENCE:0/',
             '/TRANSP:OPAQUE/',
-            '/DTEND:20121223T230000Z/',
-            '/SUMMARY:Vacations/',
-            '/CLASS:PUBLIC/',
+            '/DTEND;VALUE=DATE:20130101/',
+            '/SUMMARY:New Year’s Eve/',
+            '/CLASS:PRIVATE/',
+            '/X-MICROSOFT-CDO-ALLDAYEVENT:TRUE/',
             '/DTSTAMP:20\d{6}T\d{6}Z/',
             '/ATTACH:http:\/\/attach.example.com/',
             '/END:VEVENT/',
             '/END:VCALENDAR/',
         );
+
         foreach (explode("\n", $vCalendar->render()) as $key => $line)
         {
             $this->assertTrue(isset($lines[$key]), 'Too many lines... ' . $line);
+
             $this->assertRegExp($lines[$key], $line);
         }
     }


### PR DESCRIPTION
basic implementation of the attach property.

can be enhanced with encoding detection and inline embedding options.

references for enhanced version:
```
if (filter_var($url, FILTER_VALIDATE_URL)) {
    echo("$url is a valid URL");
} else {
    $this->setParam('FMTTYPE', 'application/binary');
}
```

```
$this->setParam('ENCODING', 'BASE64');
$this->setParam('VALUE', 'BINARY:MIICajCCAdOgAwIBAgICBEUwDQYJKoZIhvcNAQEEBQAwdzELMAkGA1UEBhMCVVMxLDAqBgNVBAoTI05ldHNjYXBlIENvbW11bmljYXRpb25zIE');
$this->setParam('FMTTYPE', 'application/binary');
$this->setParam('FMTTYPE', 'image/basic');
```


```
ATTACH;FMTTYPE=image/basic;ENCODING=BASE64;VALUE=BINARY:
MIICajCCAdOgAwIBAgICBEUwDQYJKoZIhvcNAQEEBQAwdzELMAkGA1U
EBhMCVVMxLDAqBgNVBAoTI05ldHNjYXBlIENvbW11bmljYXRpb25zIE
<...remainder of "BASE64" encoded binary data...>

ATTACH;FMTTYPE=application/binary:ftp://domain.com/pub/docs/
agenda.doc
```

links:
- https://www.kanzaki.com/docs/ical/attach.html
- https://www.ietf.org/rfc/rfc2445.txt