### PR TITLE
Bug related to DateTimeImmutable

### DIFF
--- a/src/Util/DateUtil.php
+++ b/src/Util/DateUtil.php
@@ -50,7 +50,7 @@ class DateUtil
         // Do not convert DateTime to UTC if a timezone it specified, as it should be local time.
         if (!$noTime && $useUtc && !$useTimezone) {
             $dateTime = clone $dateTime;
-            $dateTime->setTimezone(new \DateTimeZone('UTC'));
+            $dateTime = $dateTime->setTimezone(new \DateTimeZone('UTC'));
         }
 
         return $dateTime->format(self::getDateFormat($noTime, $useTimezone, $useUtc));

--- a/tests/Eluceo/iCal/Util/DateUtilTest.php
+++ b/tests/Eluceo/iCal/Util/DateUtilTest.php
@@ -14,6 +14,14 @@ class DateUtilTest extends TestCase
 
         $this->assertEquals('19991231T140000Z', $dateString);
     }
+    
+    public function testTimeConvertsToUTCWithDateTimeImmutable()
+    {
+        $dateTime   = new \DateTimeImmutable('2000-01-01T00:00:00+1000');
+        $dateString = DateUtil::getDateString($dateTime, false, false, true);
+
+        $this->assertEquals('19991231T140000Z', $dateString);
+    }
 
     public function testNoTimezoneConversionForDateOnly()
     {


### PR DESCRIPTION
Example:
```php
<?php
date_default_timezone_set('Europe/Berlin'); // so CEST = UTC+2
$vCalendar = new Calendar('Some cool event');
$vEvent = new Event();
$vEvent->setSummary('Some cool event')
            ->setLocation('Somewhere cool')
            ->setDtStart(new \DateTimeImmutable('2019-05-04 11:00:00'))
            ->setDtEnd(new \DateTimeImmutable('2019-05-06 13:00:00'));
$vCalendar->addComponent($vEvent);
echo $vCalendar->render();
```

Expected output:
```
[...]
DTSTART:20190504T090000Z
[...]
DTEND:20190506T110000Z
[...]
```

Actual output:
```
[...]
DTSTART:20190504T110000Z
[...]
DTEND:20190506T130000Z
[...]
```


The code would work like expected if i change the \DateTimeImmutable to \DateTime but all methods expect \DateTimeInterface so a \DateTimeImmutable should work too.

The problem is at the DateUtil::getDateString() method (see change).