### PR TITLE
Do not escape new lines ("\n")

### DIFF
--- a/src/Property/StringValue.php
+++ b/src/Property/StringValue.php
@@ -33,7 +33,6 @@ class StringValue implements ValueInterface
         $value = str_replace('"', '\\"', $value);
         $value = str_replace(',', '\\,', $value);
         $value = str_replace(';', '\\;', $value);
-        $value = str_replace("\n", '\\n', $value);
         $value = str_replace([
             "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07",
             "\x08", "\x09", /* \n*/ "\x0B", "\x0C", "\x0D", "\x0E", "\x0F",

--- a/tests/Eluceo/iCal/ComponentTest.php
+++ b/tests/Eluceo/iCal/ComponentTest.php
@@ -42,7 +42,7 @@ class ComponentTest extends TestCase
         $vCalendar->addComponent($vEvent);
 
         $output = $vCalendar->render();
-        $this->assertContains(str_replace("\n", "\\n", $input), $output);
+        $this->assertNotContains(str_replace("\n", "\\n", $input), $output);
     }
 
     public function testAddComponentOnKey()
@@ -58,7 +58,7 @@ class ComponentTest extends TestCase
         $vCalendar->addComponent($vEvent, 'eventKey');
 
         $output = $vCalendar->render();
-        $this->assertContains(str_replace("\n", "\\n", $input), $output);    
+        $this->assertNotContains(str_replace("\n", "\\n", $input), $output);
     }
 
     public function testSetComponents()

--- a/tests/Eluceo/iCal/Property/StringValueTest.php
+++ b/tests/Eluceo/iCal/Property/StringValueTest.php
@@ -55,9 +55,9 @@ class StringValueTest extends TestCase
         $stringValue = new StringValue("Text with new\n line");
 
         $this->assertEquals(
-            'Text with new\\n line',
+            "Text with new\n line",
             $stringValue->getEscapedValue(),
-            'Escape new line to text'
+            'Do not escape new line to text'
         );
     }
 


### PR DESCRIPTION
According to rfc5545 (https://tools.ietf.org/html/rfc5545.html#section-3.1):
"Content lines are delimited by a line break,
which is a CRLF sequence (CR character followed by LF character)."

I also tested the behaviour in Apple Calender.
When using `\n` the line break is registered when using `\\n` like the lib currently does it is not registered.

Maybe this change should only apply to the description field. I'm not sure about this.