### PR TITLE
Add property X-MICROSOFT-CDO-BUSYSTATUS #32

### DIFF
--- a/examples/example6.php
+++ b/examples/example6.php
@@ -14,6 +14,7 @@ $vEvent = new \Eluceo\iCal\Component\Event();
 $vEvent->setDtStart(new \DateTime('2012-12-24'));
 $vEvent->setDtEnd(new \DateTime('2012-12-24'));
 $vEvent->setNoTime(true);
+$vEvent->setMsBusyStatus("FREE");
 $vEvent->setSummary('Christmas');
 
 // add some location information for apple devices

--- a/examples/example7.php
+++ b/examples/example7.php
@@ -14,6 +14,7 @@ $vEvent = new \Eluceo\iCal\Component\Event();
 $vEvent->setDtStart(new \DateTime('2012-12-24'));
 $vEvent->setDtEnd(new \DateTime('2012-12-24'));
 $vEvent->setNoTime(true);
+$vEvent->setMsBusyStatus("FREE");
 $vEvent->setSummary('Christmas');
 $vEvent->setDescription('Happy Christmas!');
 $vEvent->setDescriptionHTML('<b>Happy Christmas!</b>');

--- a/src/Component.php
+++ b/src/Component.php
@@ -173,7 +173,6 @@ abstract class Component
     }
 
     /**
-     * @param array     $lines
      * @param Component $component
      */
     private function addComponentLines(array &$lines, self $component)

--- a/src/Component/Calendar.php
+++ b/src/Component/Calendar.php
@@ -303,8 +303,6 @@ class Calendar extends Component
      *
      * @see        Eluceo\iCal::addComponent
      * @deprecated Please, use public method addComponent() from abstract Component class
-     *
-     * @param Event $event
      */
     public function addEvent(Event $event)
     {

--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -36,6 +36,11 @@ class Event extends Component
     const STATUS_CONFIRMED = 'CONFIRMED';
     const STATUS_CANCELLED = 'CANCELLED';
 
+    const MS_BUSYSTATUS_FREE = 'FREE';
+    const MS_BUSYSTATUS_TENTATIVE = 'TENTATIVE';
+    const MS_BUSYSTATUS_BUSY = 'BUSY';
+    const MS_BUSYSTATUS_OOF = 'OOF';
+
     /**
      * @var string
      */
@@ -72,6 +77,11 @@ class Event extends Component
      * @var bool
      */
     protected $noTime = false;
+
+    /**
+     * @var string
+     */
+    protected $msBusyStatus = null;
 
     /**
      * @var string
@@ -356,6 +366,11 @@ class Event extends Component
             $propertyBag->set('X-MICROSOFT-CDO-ALLDAYEVENT', 'TRUE');
         }
 
+        if (null != $this->msBusyStatus) {
+            $propertyBag->set('X-MICROSOFT-CDO-BUSYSTATUS', $this->msBusyStatus);
+            $propertyBag->set('X-MICROSOFT-CDO-INTENDEDSTATUS', $this->msBusyStatus);
+        }
+
         if (null != $this->categories) {
             $propertyBag->set('CATEGORIES', $this->categories);
         }
@@ -480,6 +495,37 @@ class Event extends Component
         $this->noTime = $noTime;
 
         return $this;
+    }
+
+    /**
+     * @param $msBusyStatus
+     *
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setMsBusyStatus($msBusyStatus)
+    {
+        $msBusyStatus = strtoupper($msBusyStatus);
+        if ($msBusyStatus == self::MS_BUSYSTATUS_FREE
+            || $msBusyStatus == self::MS_BUSYSTATUS_TENTATIVE
+            || $msBusyStatus == self::MS_BUSYSTATUS_BUSY
+            || $msBusyStatus == self::MS_BUSYSTATUS_OOF
+        ) {
+            $this->msBusyStatus = $msBusyStatus;
+        } else {
+            throw new \InvalidArgumentException('Invalid value for status');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMsBusyStatus()
+    {
+        return $this->msBusyStatus;
     }
 
     /**

--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -460,10 +460,7 @@ class Event extends Component
             $geo = Geo::fromString($geo);
         } elseif (!is_null($geo) && !$geo instanceof Geo) {
             $className = get_class($geo);
-            throw new \InvalidArgumentException(
-                "The parameter 'geo' must be a string or an instance of " . Geo::class
-                . " but an instance of {$className} was given."
-            );
+            throw new \InvalidArgumentException("The parameter 'geo' must be a string or an instance of " . Geo::class . " but an instance of {$className} was given.");
         }
 
         $this->location = $location;
@@ -474,8 +471,6 @@ class Event extends Component
     }
 
     /**
-     * @param Geo $geoProperty
-     *
      * @return $this
      */
     public function setGeoLocation(Geo $geoProperty)
@@ -549,8 +544,6 @@ class Event extends Component
     }
 
     /**
-     * @param Organizer $organizer
-     *
      * @return $this
      */
     public function setOrganizer(Organizer $organizer)
@@ -645,8 +638,6 @@ class Event extends Component
     }
 
     /**
-     * @param Attendees $attendees
-     *
      * @return $this
      */
     public function setAttendees(Attendees $attendees)
@@ -787,8 +778,6 @@ class Event extends Component
     /**
      * @deprecated Deprecated since version 0.11.0, to be removed in 1.0. Use addRecurrenceRule instead.
      *
-     * @param RecurrenceRule $recurrenceRule
-     *
      * @return $this
      */
     public function setRecurrenceRule(RecurrenceRule $recurrenceRule)
@@ -813,8 +802,6 @@ class Event extends Component
     }
 
     /**
-     * @param RecurrenceRule $recurrenceRule
-     *
      * @return $this
      */
     public function addRecurrenceRule(RecurrenceRule $recurrenceRule)
@@ -883,8 +870,6 @@ class Event extends Component
     }
 
     /**
-     * @param \DateTimeInterface $dateTime
-     *
      * @return \Eluceo\iCal\Component\Event
      */
     public function addExDate(\DateTimeInterface $dateTime)
@@ -923,8 +908,6 @@ class Event extends Component
     }
 
     /**
-     * @param RecurrenceId $recurrenceId
-     *
      * @return \Eluceo\iCal\Component\Event
      */
     public function setRecurrenceId(RecurrenceId $recurrenceId)
@@ -954,9 +937,6 @@ class Event extends Component
         return $this->attachments;
     }
 
-    /**
-     * @param string $url
-     */
     public function addUrlAttachment(string $url)
     {
         $this->addAttachment(new Attachment($url));

--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -660,9 +660,6 @@ class Event extends Component
         return $this;
     }
 
-    /**
-     * @return Attendees
-     */
     public function getAttendees(): Attendees
     {
         return $this->attendees;

--- a/src/Component/TimezoneRule.php
+++ b/src/Component/TimezoneRule.php
@@ -138,8 +138,6 @@ class TimezoneRule extends Component
     }
 
     /**
-     * @param \DateTimeInterface $dtStart
-     *
      * @return $this
      */
     public function setDtStart(\DateTimeInterface $dtStart)
@@ -150,8 +148,6 @@ class TimezoneRule extends Component
     }
 
     /**
-     * @param RecurrenceRule $recurrenceRule
-     *
      * @return $this
      */
     public function setRecurrenceRule(RecurrenceRule $recurrenceRule)

--- a/src/ParameterBag.php
+++ b/src/ParameterBag.php
@@ -50,17 +50,12 @@ class ParameterBag
 
     /**
      * Checks if there are any params.
-     *
-     * @return bool
      */
     public function hasParams(): bool
     {
         return count($this->params) > 0;
     }
 
-    /**
-     * @return string
-     */
     public function toString(): string
     {
         $line = '';

--- a/src/Property.php
+++ b/src/Property.php
@@ -140,9 +140,6 @@ class Property
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;

--- a/src/Property/Event/Geo.php
+++ b/src/Property/Event/Geo.php
@@ -36,15 +36,11 @@ class Geo extends Property
         $this->longitude = $longitude;
 
         if ($this->latitude < -90 || $this->latitude > 90) {
-            throw new \InvalidArgumentException(
-                "The geographical latitude must be a value between -90 and 90 degrees. '{$this->latitude}' was given."
-            );
+            throw new \InvalidArgumentException("The geographical latitude must be a value between -90 and 90 degrees. '{$this->latitude}' was given.");
         }
 
         if ($this->longitude < -180 || $this->longitude > 180) {
-            throw new \InvalidArgumentException(
-                "The geographical longitude must be a value between -180 and 180 degrees. '{$this->longitude}' was given."
-            );
+            throw new \InvalidArgumentException("The geographical longitude must be a value between -180 and 180 degrees. '{$this->longitude}' was given.");
         }
 
         parent::__construct('GEO', new Property\RawStringValue($this->getGeoLocationAsString()));
@@ -52,8 +48,6 @@ class Geo extends Property
 
     /**
      * @deprecated This method is used to allow backwards compatibility for Event::setLocation
-     *
-     * @param string $geoLocationString
      *
      * @return Geo
      */
@@ -70,8 +64,6 @@ class Geo extends Property
      * Returns the coordinates as a string.
      *
      * @example 37.386013;-122.082932
-     *
-     * @param string $separator
      *
      * @return string
      */

--- a/src/Property/Event/Geo.php
+++ b/src/Property/Event/Geo.php
@@ -64,25 +64,17 @@ class Geo extends Property
      * Returns the coordinates as a string.
      *
      * @example 37.386013;-122.082932
-     *
-     * @return string
      */
     public function getGeoLocationAsString(string $separator = ';'): string
     {
         return number_format($this->latitude, 6) . $separator . number_format($this->longitude, 6);
     }
 
-    /**
-     * @return float
-     */
     public function getLatitude(): float
     {
         return $this->latitude;
     }
 
-    /**
-     * @return float
-     */
     public function getLongitude(): float
     {
         return $this->longitude;

--- a/src/Property/Event/RecurrenceId.php
+++ b/src/Property/Event/RecurrenceId.php
@@ -76,8 +76,6 @@ class RecurrenceId extends Property
     }
 
     /**
-     * @param \DateTimeInterface $dateTime
-     *
      * @return \Eluceo\iCal\Property\Event\RecurrenceId
      */
     public function setDatetime(\DateTimeInterface $dateTime)

--- a/src/Property/Event/RecurrenceRule.php
+++ b/src/Property/Event/RecurrenceRule.php
@@ -207,8 +207,6 @@ class RecurrenceRule implements ValueInterface
     }
 
     /**
-     * @param \DateTimeInterface|null $until
-     *
      * @return $this
      */
     public function setUntil(\DateTimeInterface $until = null)
@@ -465,8 +463,6 @@ class RecurrenceRule implements ValueInterface
      *
      * Each BYDAY value can also be preceded by a positive (+n) or negative (-n) integer.
      * If present, this indicates the nth occurrence of a specific day within the MONTHLY or YEARLY "RRULE".
-     *
-     * @param string $day
      *
      * @return $this
      */

--- a/src/Property/ValueInterface.php
+++ b/src/Property/ValueInterface.php
@@ -19,8 +19,6 @@ interface ValueInterface
      * Escape values as per RFC 5545.
      *
      * @see https://tools.ietf.org/html/rfc5545#section-3.3.11
-     *
-     * @return string
      */
     public function getEscapedValue(): string;
 }

--- a/src/PropertyBag.php
+++ b/src/PropertyBag.php
@@ -35,8 +35,6 @@ class PropertyBag implements \IteratorAggregate
     }
 
     /**
-     * @param string $name
-     *
      * @return Property|null
      */
     public function get(string $name)
@@ -50,8 +48,6 @@ class PropertyBag implements \IteratorAggregate
 
     /**
      * Adds a Property. If Property already exists an Exception will be thrown.
-     *
-     * @param Property $property
      *
      * @return $this
      *

--- a/tests/Eluceo/iCal/Component/EventTest.php
+++ b/tests/Eluceo/iCal/Component/EventTest.php
@@ -105,6 +105,23 @@ class EventTest extends TestCase
         $this->assertArrayHasKey('DTSTAMP', $result);
     }
 
+    public function testSetMsBusyTime()
+    {
+        $event = new Event('19960401T080045Z-4000F192713-0052@host1.com');
+        $event->setMsBusyStatus("FREE");
+        $result = $event->buildPropertyBag()->getIterator()->getArrayCopy();
+
+        $this->assertSame('X-MICROSOFT-CDO-BUSYSTATUS:FREE', $result['X-MICROSOFT-CDO-BUSYSTATUS']->toLine());
+    }
+
+    public function testGetMsBusyTime()
+    {
+        $event = new Event('19960401T080045Z-4000F192713-0052@host1.com');
+        $event->setMsBusyStatus("FREE");
+
+        $this->assertSame("FREE", $event->getMsBusyStatus());
+    }
+
     public function testSetSequence()
     {
         $event = new Event('19960401T080045Z-4000F192713-0052@host1.com');


### PR DESCRIPTION
Support for property 'X-MICROSOFT-CDO-BUSYSTATUS' in ical events. This property represents the status in Microsoft Outlook for freebusy-view. The property 'X-MICROSOFT-CDO-INTENDEDSTATUS' has the same effect and is needed for Exchange 2010, since it is still supported till january 2020.