### PR TITLE
Conflict with PHP 7.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - '7.4'
+  - '7.4.5'
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "php": ">=7.4",
         "ext-mbstring": "*"
     },
+    "conflict": {
+        "php": "7.4.6"
+    },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.2",
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Some generators are returning items twice.
This is a language bug introduced in PHP 7.4.6.

See: https://bugs.php.net/bug.php?id=79600