### PR TITLE
Execute tests with latest PHP version 7.4.7 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - '7.4.5'
+  - '7.4'
 
 cache:
   directories:


### PR DESCRIPTION
A bug in PHP 7.4.6 causes the tests to fail.

Closes #163