### PR TITLE
Make setting the location a little easier

### DIFF
--- a/src/Domain/Entity/Event.php
+++ b/src/Domain/Entity/Event.php
@@ -138,8 +138,16 @@ class Event
         return $this->location;
     }
 
-    public function setLocation(?Location $location): self
+    /**
+     * @param string|Location $location
+     * @return $this
+     */
+    public function setLocation($location): self
     {
+        if (is_string($location)) {
+            $location = new Location($location);
+        }
+
         $this->location = $location;
 
         return $this;

--- a/tests/Unit/Presentation/Factory/EventFactoryTest.php
+++ b/tests/Unit/Presentation/Factory/EventFactoryTest.php
@@ -82,6 +82,18 @@ class CalendarFactoryTest extends TestCase
         );
     }
 
+    public function testEventWithLocationAsString()
+    {
+        $event = (new Event())->setLocation('Location Name');
+
+        self::assertEventRendersCorrect(
+            $event,
+            [
+                'LOCATION:Location Name',
+            ]
+        );
+    }
+
     public function testSingleDayEvent()
     {
         $event = (new Event())->setOccurrence(new SingleDay(new Date(DateTimeImmutable::createFromFormat('Y-m-d', '2030-12-24'))));


### PR DESCRIPTION
It makes sense to me to let a string be passed in since that's a common situation for a `Location` value.

Also, I'm participating in Hacktoberfest, if you accept this would you mind please [tagging hacktoberfest-accepted](https://hacktoberfest.digitalocean.com/hacktoberfest-update) on the issue for me? Thanks so much!