### PR TITLE
Switch from uuid_create() to random_bytes()

### DIFF
--- a/src/Domain/ValueObject/UniqueIdentifier.php
+++ b/src/Domain/ValueObject/UniqueIdentifier.php
@@ -25,8 +25,8 @@ final class UniqueIdentifier
 
     public static function createRandom(): self
     {
-        if (function_exists('uuid_create') && defined('UUID_TYPE_RANDOM')) {
-            return new self((string) uuid_create(UUID_TYPE_RANDOM));
+        if (function_exists('random_bytes')) {
+            return new self((string) bin2hex(random_bytes(16)));
         }
 
         return new self(uniqid());

--- a/src/Domain/ValueObject/UniqueIdentifier.php
+++ b/src/Domain/ValueObject/UniqueIdentifier.php
@@ -26,7 +26,7 @@ final class UniqueIdentifier
     public static function createRandom(): self
     {
         if (function_exists('random_bytes')) {
-            return new self((string) bin2hex(random_bytes(16)));
+            return new self(bin2hex(random_bytes(16)));
         }
 
         return new self(uniqid());


### PR DESCRIPTION
`uuid_create()` is not a PHP core function, but `random_bytes()` is and has been since PHP 7.0 (03 Dec 2015)

Therefore a more sensible way to generate a UUID is the one-liner `bin2hex(random_bytes(16))`.  This code switches `function_exists()` check from `uuid_create()` to `random_bytes()`