### PR TITLE
Cleanup Makefile and avoid composer install if vendor folder is present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,25 +13,25 @@ INFECTION_FLAGS ?=
 help:
 	@echo 'Available targets'
 	@echo '  clean               Removes temporary build artifacts like'
-	@echo '  dependencies        Installs composer dependencies'
 	@echo '  docs                Builds the documentation website'
 	@echo '  fix                 Fixes composer.json and code style'
 	@echo '  fix-prettier        Fix code style of non PHP files (not included in "fix" target)'
 	@echo '  test                Execute all tests'
+	@echo '  vendor              Installs composer vendor'
 
 .PHONY: test
 test: test-validate-composer test-code-style test-psalm test-phpunit test-examples test-composer-normalize test-phpmd test-infection
 
 .PHONY: test-code-style
-test-code-style: dependencies
+test-code-style: vendor
 	php-cs-fixer fix --dry-run --diff
 
 .PHONY: test-psalm
-test-psalm: dependencies
+test-psalm: vendor
 	psalm -m --no-progress ${PSALM_FLAGS}
 
 .PHONY: test-phpunit
-test-phpunit: dependencies
+test-phpunit: vendor
 	phpunit --coverage-xml=build/coverage/coverage-xml --log-junit=build/coverage/junit.xml ${PHPUNIT_FLAGS}
 
 .PHONY: test-examples
@@ -39,11 +39,11 @@ EXAMPLE_FILES := $(wildcard examples/*.php)
 test-examples: $(EXAMPLE_FILES)
 
 .PHONY: test-infection
-test-infection: dependencies test-phpunit
+test-infection: vendor test-phpunit
 test-infection:
 	infection --min-msi=60 --coverage=build/coverage ${INFECTION_FLAGS}
 
-examples/example*.php: dependencies
+examples/example*.php: vendor
 	php $@ > /dev/null
 
 .PHONY: test-validate-composer
@@ -51,12 +51,12 @@ test-validate-composer:
 	composer validate
 
 .PHONY: test-composer-normalize
-test-composer-normalize: dependencies
+test-composer-normalize: vendor
 test-composer-normalize:
 	composer normalize --dry-run --diff
 
 .PHONY: test-phpmd
-test-phpmd: dependencies
+test-phpmd: vendor
 test-phpmd:
 	phpmd ./src text rulesets.xml
 
@@ -65,41 +65,42 @@ test-prettier:
 	yarn
 	npx prettier --check .
 
-.PHONY: dependencies
-dependencies:
+vendor: composer.json composer.lock
 	composer install --no-interaction
 
 .PHONY: fix
 fix: fix-code-style fix-composer
 
 .PHONY: fix-code-style
-fix-code-style: dependencies
+fix-code-style: vendor
 fix-code-style:
 	php-cs-fixer -- fix
 
 .PHONY: fix-composer
-fix-composer: dependencies
+fix-composer: vendor
 fix-composer:
 	composer normalize --no-update-lock
 	composer update nothing
 
 .PHONY: fix-prettier
-fix-prettier:
-	yarn
+fix-prettier: node_modules
 	npx prettier --write .
 
+node_modules: yarn.lock package.json
+	yarn
+
 .PHONY: docs
-docs: docs-dependencies
+docs: docs-vendor
 	cd  website && yarn build
 
-.PHONY: docs-dependencies
-docs-dependencies:
+.PHONY: docs-vendor
+docs-vendor:
 	cd website && yarn
 
 .PHONY: docs-preview
-docs-preview: docs-dependencies
+docs-preview: docs-vendor
 	cd website && yarn start
 
 .PHONY: clean
 clean:
-	rm -rf vendor website/node_modules website/build website/.docusaurus node_modules .phpunit.result.cache .php_cs.cache build
+	rm -rf vendor website/node_modules website/build website/.docusaurus node_modules .phpunit.result.cache .php-cs-fixer.cache build


### PR DESCRIPTION
* remove PHP-CS-Cache v3 with make clean
* dont use phony target for composer dependencies:
  don't install composer dependencies if already installed
  this will speedup `make test` locally
* dont install node_modules if present when `make fix-prettier` is called