### PR TITLE
Fix wrongly typed constructor argument of class `Calendar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   PHPStan complains about wrongly typed hinted constructor argument of `Calendar` class. [#281](https://github.com/markuspoerschke/iCal/issues/281)
+
 ## [2.3.0] - 2021-08-24
 
 ### Added

--- a/src/Domain/Collection/EventsArray.php
+++ b/src/Domain/Collection/EventsArray.php
@@ -17,12 +17,12 @@ use Eluceo\iCal\Domain\Entity\Event;
 final class EventsArray extends Events
 {
     /**
-     * @var Event[]
+     * @var array<int, Event>
      */
     private array $events = [];
 
     /**
-     * @param Event[] $events
+     * @param array<array-key, Event> $events
      */
     public function __construct(array $events)
     {

--- a/src/Domain/Entity/Calendar.php
+++ b/src/Domain/Entity/Calendar.php
@@ -29,7 +29,7 @@ class Calendar
     private array $timeZones = [];
 
     /**
-     * @param Event[]|Iterator<Event>|Events $events
+     * @param array<array-key, Event>|Iterator<Event>|Events $events
      */
     public function __construct($events = [])
     {
@@ -37,7 +37,7 @@ class Calendar
     }
 
     /**
-     * @param Event[]|Iterator<Event>|Events $events
+     * @param array<array-key, Event>|Iterator<Event>|Events $events
      */
     private function ensureEventsObject($events = []): Events
     {


### PR DESCRIPTION
Fixes #281