### PR TITLE
Make compatible with EasyAdmin 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Event Attendee property [#333](https://github.com/markuspoerschke/iCal/pull/314)
+-   Support `symfony/deprecation-contracts` version 3 [#354](https://github.com/markuspoerschke/iCal/pull/354)
+-   Event Attendee property [#333](https://github.com/markuspoerschke/iCal/pull/333)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.4 || ~8.0.0",
         "ext-mbstring": "*",
-        "symfony/deprecation-contracts": "^2.1|^3.0"
+        "symfony/deprecation-contracts": "^2.1 || ^3.0"
     },
     "conflict": {
         "php": "7.4.6"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.4 || ~8.0.0",
         "ext-mbstring": "*",
-        "symfony/deprecation-contracts": "^2.1"
+        "symfony/deprecation-contracts": "^2.1|^3.0"
     },
     "conflict": {
         "php": "7.4.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d25383e6d43534c733eb0213aac12176",
+    "content-hash": "c66ebcc111a2febb8536b91b208f8ec8",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1476d26d71307e0e2a9a346a14dfc23e",
+    "content-hash": "d25383e6d43534c733eb0213aac12176",
     "packages": [
         {
             "name": "symfony/deprecation-contracts",
@@ -6060,6 +6060,7 @@
                 "issues": "https://github.com/webmozart/path-util/issues",
                 "source": "https://github.com/webmozart/path-util/tree/2.3.0"
             },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],


### PR DESCRIPTION
EasyAdmin v4.x requires symfony/deprecation-contracts 3.0.0 or higher, which conflicts with this required one