### PR TITLE
PHP 8.1

### DIFF
--- a/src/Domain/Collection/Events.php
+++ b/src/Domain/Collection/Events.php
@@ -14,12 +14,14 @@ namespace Eluceo\iCal\Domain\Collection;
 use Eluceo\iCal\Domain\Entity\Event;
 use Iterator;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 
 abstract class Events implements IteratorAggregate
 {
     /**
      * @return Iterator<Event>
      */
+    #[ReturnTypeWillChange]
     abstract public function getIterator();
 
     abstract public function addEvent(Event $event): void;

--- a/src/Domain/Collection/EventsArray.php
+++ b/src/Domain/Collection/EventsArray.php
@@ -13,6 +13,7 @@ namespace Eluceo\iCal\Domain\Collection;
 
 use ArrayIterator;
 use Eluceo\iCal\Domain\Entity\Event;
+use ReturnTypeWillChange;
 
 final class EventsArray extends Events
 {
@@ -29,6 +30,7 @@ final class EventsArray extends Events
         array_walk($events, [$this, 'addEvent']);
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->events);

--- a/src/Domain/Collection/EventsGenerator.php
+++ b/src/Domain/Collection/EventsGenerator.php
@@ -14,6 +14,7 @@ namespace Eluceo\iCal\Domain\Collection;
 use BadMethodCallException;
 use Eluceo\iCal\Domain\Entity\Event;
 use Iterator;
+use ReturnTypeWillChange;
 
 final class EventsGenerator extends Events
 {
@@ -30,6 +31,7 @@ final class EventsGenerator extends Events
         $this->generator = $generator;
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->generator;

--- a/src/Presentation/Component.php
+++ b/src/Presentation/Component.php
@@ -14,6 +14,7 @@ namespace Eluceo\iCal\Presentation;
 use Eluceo\iCal\Presentation\Component\Property;
 use Generator;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 
 class Component implements IteratorAggregate
 {
@@ -56,6 +57,7 @@ class Component implements IteratorAggregate
         );
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getContentLines();


### PR DESCRIPTION
Fixed deprecation messages in PHP 8.1, i.e.:
```
Return type of Eluceo\iCal\Presentation\Component::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/iCal/src/Presentation/Component.php on line 59
```