### PR TITLE
Document DateTime's $applyTimeZone arg

### DIFF
--- a/website/docs/component-event.md
+++ b/website/docs/component-event.md
@@ -201,6 +201,8 @@ $event->setOccurrence($occurrence);
 
 describes an event that takes place between 1pm and 2pm on 3rd of january 2020.
 
+For calendars which include [time zone data](./component-timezone), set the second argument of `DateTime` to `true` to include the time zone with the resulting timestamp.
+
 ### Location
 
 The location defines where an event takes place.

--- a/website/docs/component-timezone.md
+++ b/website/docs/component-timezone.md
@@ -32,6 +32,15 @@ $timeZone = TimeZone::createFromPhpDateTimeZone(
 );
 ```
 
+Timespan events in calendars with time zones should set the `DateTime` `$applyTimeZone` argument to `true` to include time zones with the resulting timestamps.
+
+```php
+use Eluceo\iCal\Domain\ValueObject\TimeSpan;
+use Eluceo\iCal\Domain\ValueObject\DateTime;
+
+new TimeSpan(new DateTime($starTime, true), new DateTime($endTime, true));
+```
+
 ## Recurrence rules
 
 Not implemented yet.


### PR DESCRIPTION
Added brief explanations about setting the `$applyTimeZone` argument to `DateTime` objects in `TimeSpan`s. Got burned by this, then found the answer by reading the source code. Hoping to save the next user some time. Thank you for a great library!