### PR TITLE
Fix code style before open release PR

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -36,6 +36,11 @@ jobs:
           commit_message: Release ${{ github.event.inputs.version }}
           file_pattern: CHANGELOG.md
 
+      - name: Fix code style
+        uses: actionsx/prettier@v2
+        with:
+          args: --write CHANGELOG.md
+
       - name: Create pull request
         uses: thomaseizinger/create-pull-request@1.2.2
         env:


### PR DESCRIPTION
Avoid having a second build in release Pull Requests (PRs), the code style will be fixed, before the PR is opened.

![image](https://user-images.githubusercontent.com/1222377/153771572-19c0cbbb-6bdd-43be-abeb-131f1cff7368.png)

Commits like shown in the screenshot are avoided by this change.
