### PR TITLE
Fix deprecation on PHP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Deprecation message occuring on an OOTB Symfony 5.4 on PHP 7.4 [#382](https://github.com/markuspoerschke/iCal/pull/382)
+
 ## [2.5.0] - 2022-02-13
 
 ### Added

--- a/src/Presentation/Component.php
+++ b/src/Presentation/Component.php
@@ -15,6 +15,7 @@ use Eluceo\iCal\Presentation\Component\Property;
 use Generator;
 use IteratorAggregate;
 use ReturnTypeWillChange;
+use Traversable;
 
 class Component implements IteratorAggregate
 {
@@ -57,6 +58,9 @@ class Component implements IteratorAggregate
         );
     }
 
+    /**
+     * @return Traversable
+     */
     #[ReturnTypeWillChange]
     public function getIterator()
     {

--- a/src/Presentation/Component.php
+++ b/src/Presentation/Component.php
@@ -58,11 +58,8 @@ class Component implements IteratorAggregate
         );
     }
 
-    /**
-     * @return Traversable
-     */
     #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return $this->getContentLines();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #345
| License       | MIT

This PR fixes the deprecation message occuring on an OOTB Symfony 5.4 on PHP 7.4:

> User Deprecated: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "Eluceo\iCal\Presentation\Component" now to avoid errors or add an explicit @return annotation to suppress this message.

The other issues outlined in #369 should already be solved, as the `#[ReturnTypeWillChange]` annotations are already present in those classes.

Thank you very much for the awesome library and best regards from Austria
Andreas