### PR TITLE
Support PHP 8.1 by v0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.php_cs.cache
+.phpunit.result.cache
 /composer.lock
 /vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,7 @@ cache:
 
 jobs:
   include:
-    # Matrix Builds (7.1 - 8.0)
-    - <<: *test-unit
-      name: PHP 7.1
-      php: 7.1
-
-    - <<: *test-unit
-      name: PHP 7.2
-      php: 7.2
-
-    - <<: *test-unit
-      name: PHP 7.3
-      php: 7.3
-
+    # Matrix Builds (7.4 - 8.1)
     - <<: *test-unit
       name: PHP 7.4
       php: 7.4
@@ -40,6 +28,11 @@ jobs:
 
     - <<: *test-unit
       name: PHP 8.0
+      php: master
+      env: COMPOSER_FLAGS="--ignore-platform-reqs"
+
+    - <<: *test-unit
+      name: PHP 8.1
       php: master
       env: COMPOSER_FLAGS="--ignore-platform-reqs"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Support PHP 8.1
+### Changed
+- Use PHPUnit v9.5
+### Removed
+- Support for EOL PHP versions (7.1, 7.2, 7.3)
+
 ## [0.16.1]
 ### Added
 - Support PHP 8.0 [#194](https://github.com/markuspoerschke/iCal/pull/194)

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
         }
     },
     "require": {
-        "php": ">=7.1 || ~8.0.0"
+        "php": ">=7.4"
     },
     "suggest": {
         "ext-mbstring" : "Massive performance enhancement of line folding"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.5"
     },
     "scripts": {
         "test": "phpunit"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="./vendor/autoload.php">
-    <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" showOnlySummary="true"/>
-    </logging>
+         bootstrap="./vendor/autoload.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <text outputFile="php://stdout" showUncoveredFiles="true" showOnlySummary="true"/>
+        </report>
+    </coverage>
+    <logging/>
     <testsuites>
         <testsuite name="eluceo iCal Test Suite">
             <directory suffix="Test.php">./tests/Eluceo/iCal/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Property/Event/RecurrenceRule.php
+++ b/src/Property/Event/RecurrenceRule.php
@@ -245,9 +245,13 @@ class RecurrenceRule implements ValueInterface
      */
     public function setFreq($freq)
     {
-        if (@constant('static::FREQ_' . $freq) !== null) {
-            $this->freq = $freq;
-        } else {
+        try {
+            if (@constant('static::FREQ_' . $freq) !== null) {
+                $this->freq = $freq;
+            } else {
+                throw new \InvalidArgumentException("The Frequency {$freq} is not supported.");
+            }
+        } catch (\Error $error) {
             throw new \InvalidArgumentException("The Frequency {$freq} is not supported.");
         }
 

--- a/src/PropertyBag.php
+++ b/src/PropertyBag.php
@@ -66,7 +66,7 @@ class PropertyBag implements \IteratorAggregate
         return $this;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayObject($this->elements);
     }

--- a/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
+++ b/tests/Eluceo/iCal/Component/CalendarIntegrationTest.php
@@ -61,7 +61,7 @@ class CalendarIntegrationTest extends TestCase
         {
             $this->assertTrue(isset($lines[$key]), 'Too many lines... ' . $line);
 
-            $this->assertRegExp($lines[$key], $line);
+            $this->assertMatchesRegularExpression($lines[$key], $line);
         }
     }
 
@@ -116,7 +116,7 @@ class CalendarIntegrationTest extends TestCase
         {
             $this->assertTrue(isset($lines[$key]), 'Too many lines... ' . $line);
 
-            $this->assertRegExp($lines[$key], $line);
+            $this->assertMatchesRegularExpression($lines[$key], $line);
         }
     }
 
@@ -191,7 +191,7 @@ class CalendarIntegrationTest extends TestCase
         {
             $this->assertTrue(isset($lines[$key]), 'Too many lines... ' . $line);
 
-            $this->assertRegExp($lines[$key], $line);
+            $this->assertMatchesRegularExpression($lines[$key], $line);
         }
     }
 }

--- a/tests/Eluceo/iCal/Component/CalendarTest.php
+++ b/tests/Eluceo/iCal/Component/CalendarTest.php
@@ -6,12 +6,11 @@ use PHPUnit\Framework\TestCase;
 
 class CalendarTest extends TestCase
 {
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage PRODID cannot be empty
-     */
     public function testConstructorThrowsUnexpectedValueException()
     {
+        $this->expectExceptionMessage("PRODID cannot be empty");
+        $this->expectException(\UnexpectedValueException::class);
+
         new Calendar(null);
     }
 
@@ -108,6 +107,6 @@ class CalendarTest extends TestCase
         $calendar = new Calendar('-//ABC Corporation//NONSGML My Product//EN');
         $calendar->addEvent(new Event('unique_id'));
 
-        $this->assertContains("unique_id", $calendar->render());
+        $this->assertStringContainsString("unique_id", $calendar->render());
     }
 }

--- a/tests/Eluceo/iCal/Component/EventTest.php
+++ b/tests/Eluceo/iCal/Component/EventTest.php
@@ -65,12 +65,11 @@ class EventTest extends TestCase
         $this->assertSame('LOCATION:Conference Room - F123\, Bldg. 002', $result['LOCATION']->toLine());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The parameter 'geo' must be a string or an instance of Eluceo\iCal\Property\Event\Geo but an instance of ArrayObject was given.
-     */
     public function testSetLocationOnInvalidGeo()
     {
+        $this->expectExceptionMessage("The parameter 'geo' must be a string or an instance of Eluceo\iCal\Property\Event\Geo but an instance of ArrayObject was given.");
+        $this->expectException(\InvalidArgumentException::class);
+
         $event = new Event('19960401T080045Z-4000F192713-0052@host1.com');
         $event->setLocation('Conference Room - F123, Bldg. 002', '', new \ArrayObject([25.632, 122.072]));
         $result = $event->buildPropertyBag()->getIterator()->getArrayCopy();

--- a/tests/Eluceo/iCal/ComponentTest.php
+++ b/tests/Eluceo/iCal/ComponentTest.php
@@ -26,7 +26,7 @@ class ComponentTest extends TestCase
 
         $output = $vCalendar->render();
         $output = preg_replace('/\r\n /u', '', $output);
-        $this->assertContains($input, $output);
+        $this->assertStringContainsString($input, $output);
     }
 
     public function testDescriptionWithNewLines()
@@ -42,7 +42,7 @@ class ComponentTest extends TestCase
         $vCalendar->addComponent($vEvent);
 
         $output = $vCalendar->render();
-        $this->assertContains(str_replace("\n", "\\n", $input), $output);
+        $this->assertStringContainsString(str_replace("\n", "\\n", $input), $output);
     }
 
     public function testAddComponentOnKey()
@@ -58,7 +58,7 @@ class ComponentTest extends TestCase
         $vCalendar->addComponent($vEvent, 'eventKey');
 
         $output = $vCalendar->render();
-        $this->assertContains(str_replace("\n", "\\n", $input), $output);    
+        $this->assertStringContainsString(str_replace("\n", "\\n", $input), $output);
     }
 
     public function testSetComponents()
@@ -80,8 +80,8 @@ class ComponentTest extends TestCase
         $vCalendar->setComponents([$vEventTwo]);
 
         $output = $vCalendar->render();
-        $this->assertContains($shouldBeFound, $output);
-        $this->assertNotContains($shouldNotBeFound, $output);
+        $this->assertStringContainsString($shouldBeFound, $output);
+        $this->assertStringNotContainsString($shouldNotBeFound, $output);
     }
 
     public function testToString()

--- a/tests/Eluceo/iCal/Property/Event/AttendeesTest.php
+++ b/tests/Eluceo/iCal/Property/Event/AttendeesTest.php
@@ -30,22 +30,20 @@ class AttendeesTest extends TestCase
         $this->assertCount(0, $attendees->getValue());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Cannot call setParam on Attendees Property
-     */
     public function testSetParamThrowsBadMethodCallException()
     {
+        $this->expectExceptionMessage("Cannot call setParam on Attendees Property");
+        $this->expectException(\BadMethodCallException::class);
+
         $attendees = new Attendees();
         $attendees->setParam('MAILTO', 'DEV-GROUP@host2.com');
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Cannot call getParam on Attendees Property
-     */
     public function testGetParamThrowsBadMethodCallException()
     {
+        $this->expectExceptionMessage("Cannot call getParam on Attendees Property");
+        $this->expectException(\BadMethodCallException::class);
+
         $attendees = new Attendees();
         $attendees->getParam('MAILTO');
     }

--- a/tests/Eluceo/iCal/Property/Event/GeoTest.php
+++ b/tests/Eluceo/iCal/Property/Event/GeoTest.php
@@ -13,21 +13,19 @@ class GeoTest extends TestCase
         $this->assertInstanceOf(Geo::class, $geo);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The geographical latitude must be a value between -90 and 90 degrees. '-100' was given.
-     */
     public function testConstructorOnInvalidLatitude()
     {
+        $this->expectExceptionMessage("The geographical latitude must be a value between -90 and 90 degrees. '-100' was given.");
+        $this->expectException(\InvalidArgumentException::class);
+
         new Geo(-100, 122.072);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The geographical longitude must be a value between -180 and 180 degrees. '-200' was given.
-     */
     public function testConstructorOnInvalidLongitude()
     {
+        $this->expectExceptionMessage("The geographical longitude must be a value between -180 and 180 degrees. '-200' was given.");
+        $this->expectException(\InvalidArgumentException::class);
+
         new Geo(25.632, -200);
     }
 

--- a/tests/Eluceo/iCal/Property/Event/RecurrenceIdTest.php
+++ b/tests/Eluceo/iCal/Property/Event/RecurrenceIdTest.php
@@ -8,7 +8,7 @@ class RecurrenceIdTest extends TestCase
 {
     public function testConstructorOnDateTime()
     {
-        $this->assertInstanceOf(RecurrenceId::class, new RecurrenceId(new \DateTime(null, new \DateTimeZone('Asia/Taipei'))));
+        $this->assertInstanceOf(RecurrenceId::class, new RecurrenceId(new \DateTime('now', new \DateTimeZone('Asia/Taipei'))));
     }
 
     public function testConstructorOnNullDateTime()
@@ -21,7 +21,7 @@ class RecurrenceIdTest extends TestCase
         $recurrenceId = new RecurrenceId();
         $recurrenceId->applyTimeSettings();
 
-        $this->assertContains(date('Ymd'), $recurrenceId->getValue()->getValue());
+        $this->assertStringContainsString(date('Ymd'), $recurrenceId->getValue()->getValue());
     }
 
     public function testApplyTimeSettingsOnRange()
@@ -30,7 +30,7 @@ class RecurrenceIdTest extends TestCase
         $recurrenceId->setRange('RANGE=THISANDPRIOR:19980401T133000Z');
         $recurrenceId->applyTimeSettings();
 
-        $this->assertContains(date('Ymd'), $recurrenceId->getValue()->getValue());
+        $this->assertStringContainsString(date('Ymd'), $recurrenceId->getValue()->getValue());
     }
 
     public function testApplyTimeSettingsOnDefaultParams()
@@ -38,13 +38,13 @@ class RecurrenceIdTest extends TestCase
         $recurrenceId = new RecurrenceId();
         $recurrenceId->applyTimeSettings(true, true, true, 'Europe/Berlin');
 
-        $this->assertContains(date('Ymd'), $recurrenceId->getValue()->getValue());
+        $this->assertStringContainsString(date('Ymd'), $recurrenceId->getValue()->getValue());
         $this->assertSame(date('Ymd'), $recurrenceId->getValue()->getValue());
     }
 
     public function testGetDatetime()
     {
-        $recurrenceId = new RecurrenceId(new \DateTime(null, new \DateTimeZone('Europe/Berlin')));
+        $recurrenceId = new RecurrenceId(new \DateTime('now', new \DateTimeZone('Europe/Berlin')));
 
         $this->assertInstanceOf(\DateTime::class, $recurrenceId->getDatetime());
         $this->assertSame('Europe/Berlin', $recurrenceId->getDatetime()->getTimeZone()->getName());
@@ -53,7 +53,7 @@ class RecurrenceIdTest extends TestCase
     public function testSetDatetime()
     {
         $recurrenceId = new RecurrenceId();
-        $recurrenceId->setDatetime(new \DateTime(null, new \DateTimeZone('Asia/Taipei')));
+        $recurrenceId->setDatetime(new \DateTime('now', new \DateTimeZone('Asia/Taipei')));
 
         $this->assertInstanceOf(\DateTime::class, $recurrenceId->getDatetime());
         $this->assertSame('Asia/Taipei', $recurrenceId->getDatetime()->getTimeZone()->getName());
@@ -82,12 +82,11 @@ class RecurrenceIdTest extends TestCase
         $this->assertSame(['RECURRENCE-ID:value1'], $recurrenceId->toLines());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The value must implement the ValueInterface.
-     */
     public function testToLinesThrowsException()
     {
+        $this->expectExceptionMessage("The value must implement the ValueInterface.");
+        $this->expectException(\Exception::class);
+
         $recurrenceId = new RecurrenceId();
 
         $recurrenceId->toLines();

--- a/tests/Eluceo/iCal/Property/Event/RecurrenceRuleTest.php
+++ b/tests/Eluceo/iCal/Property/Event/RecurrenceRuleTest.php
@@ -60,12 +60,11 @@ class RecurrenceRuleTest extends TestCase
         $this->assertSame('1997-12-24', $result->format('Y-m-d'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The Frequency invalid_freq_string is not supported.
-     */
     public function testSetFreqOnInvalidFreq()
     {
+        $this->expectExceptionMessage("The Frequency invalid_freq_string is not supported.");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setFreq('invalid_freq_string');
     }
@@ -115,11 +114,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidMonthProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYMONTH
      */
     public function testSetByMonthOnInvalidMonth($month)
     {
+        $this->expectExceptionMessage("Invalid value for BYMONTH");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setByMonth($month);
     }
@@ -144,11 +144,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidByWeekNoProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYWEEKNO
      */
     public function testSetByWeekNoOnInvalidByWeekNo($byWeekNo)
     {
+        $this->expectExceptionMessage("Invalid value for BYWEEKNO");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setByWeekNo($byWeekNo);
     }
@@ -173,11 +174,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidByYearDayProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYYEARDAY
      */
     public function testSetByYearDayOnInvalidByYeraDay($day)
     {
+        $this->expectExceptionMessage("Invalid value for BYYEARDAY");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setByYearDay($day);
     }
@@ -202,11 +204,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidByMonthDayProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYMONTHDAY
      */
     public function testSetByMonthDayOnInvalidByMonthDay($day)
     {
+        $this->expectExceptionMessage("Invalid value for BYMONTHDAY");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setByMonthDay($day);
     }
@@ -230,11 +233,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidByHourProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYHOUR
      */
     public function testSetByHourOnInvalidByHour($value)
     {
+        $this->expectExceptionMessage("Invalid value for BYHOUR");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setByHour($value);
     }
@@ -258,11 +262,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidByMinuteProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYMINUTE
      */
     public function testSetByMinuteOnInvalidByMinute($value)
     {
+        $this->expectExceptionMessage("Invalid value for BYMINUTE");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setByMinute($value);
     }
@@ -286,11 +291,12 @@ class RecurrenceRuleTest extends TestCase
 
     /**
      * @dataProvider invalidBySecondProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid value for BYSECOND
      */
     public function testSetBySecondOnInvalidBySecond($value)
     {
+        $this->expectExceptionMessage("Invalid value for BYSECOND");
+        $this->expectException(\InvalidArgumentException::class);
+
         $rule = new RecurrenceRule();
         $rule->setBySecond($value);
     }

--- a/tests/Eluceo/iCal/PropertyBagTest.php
+++ b/tests/Eluceo/iCal/PropertyBagTest.php
@@ -6,12 +6,11 @@ use PHPUnit\Framework\TestCase;
 
 class PropertyBagTest extends TestCase
 {
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Property with name 'propName' already exists
-     */
     public function testPropertyAlreadyExistsOnAddingProperty()
     {
+        $this->expectExceptionMessage("Property with name 'propName' already exists");
+        $this->expectException(\Exception::class);
+
         $propertyBag = new PropertyBag();
         $propertyBag->add(new Property('propName', ''));
         $propertyBag->add(new Property('propName', ''));

--- a/tests/Eluceo/iCal/PropertyTest.php
+++ b/tests/Eluceo/iCal/PropertyTest.php
@@ -57,12 +57,11 @@ class PropertyTest extends TestCase
         $this->assertSame('value1,value2', $property->getValue()->getEscapedValue());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The value must implement the ValueInterface.
-     */
     public function testSetValueOnInvalidValue()
     {
+        $this->expectExceptionMessage("The value must implement the ValueInterface.");
+        $this->expectException(\Exception::class);
+
         $property = new Property('DTSTAMP', '20131020T153112');
         $property->setValue(new \DateTimeZone('Asia/Taipei'));
     }

--- a/tests/Eluceo/iCal/Util/DateUtilTest.php
+++ b/tests/Eluceo/iCal/Util/DateUtilTest.php
@@ -46,6 +46,6 @@ class DateUtilTest extends TestCase
 
     public function testGetDefaultParamsOnUseTimezone()
     {
-        $this->assertSame(['TZID' => 'Asia/Taipei'], DateUtil::getDefaultParams(new \DateTime(null, new \DateTimeZone('Asia/Taipei')), false, true));
+        $this->assertSame(['TZID' => 'Asia/Taipei'], DateUtil::getDefaultParams(new \DateTime('now', new \DateTimeZone('Asia/Taipei')), false, true));
     }
 }


### PR DESCRIPTION
## Why

v2 still doesn't support all features

## Changes
 - Removed support for EOL PHP versions (7.1, 7.2, 7.3) [they even doesn't receive security updates, it's good for ecosystem to not maintain packages for them]
 - Use latest stable PHPUnit version (for developer experience)
 - Add return type to `public function getIterator(): \Traversable` to avoid E_DEPRECATION notes that PHP 8.1 throws