### PR TITLE
Support CATEGORIES in EVENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Support categories property on events [#421](https://github.com/markuspoerschke/iCal/pull/421)
+
 ## [2.5.1] - 2022-04-26
 
 ### Fixed

--- a/composer.lock
+++ b/composer.lock
@@ -108,13 +108,13 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Amp\\": "lib"
-                },
                 "files": [
                     "lib/functions.php",
                     "lib/Internal/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Amp\\": "lib"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -240,79 +240,6 @@
                 }
             ],
             "time": "2021-03-30T17:13:30+00:00"
-        },
-        {
-            "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1.0 || ^2.0",
-                "php": "^7 || ^8"
-            },
-            "replace": {
-                "ocramius/package-versions": "1.11.99"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9.3 || ^2.0@dev",
-                "ext-zip": "^1.13",
-                "phpunit/phpunit": "^6.5 || ^7"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "support": {
-                "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-17T14:14:24+00:00"
         },
         {
             "name": "composer/pcre",
@@ -1834,6 +1761,68 @@
             "time": "2021-11-30T19:35:32+00:00"
         },
         {
+            "name": "ocramius/package-versions",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "6707caff2e84a2368f29fdf2cb28a6b5a9e3ab53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/6707caff2e84a2368f29fdf2cb28a6b5a9e3ab53",
+                "reference": "6707caff2e84a2368f29fdf2cb28a6b5a9e3ab53",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.0",
+                "php": "~8.0.0 || ~8.1.0"
+            },
+            "replace": {
+                "composer/package-versions-deprecated": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2.0",
+                "doctrine/coding-standard": "^9.0.0",
+                "ext-zip": "^1.15.0",
+                "phpunit/phpunit": "^9.5.9",
+                "roave/infection-static-analysis-plugin": "^1.10.0",
+                "vimeo/psalm": "^4.10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/Ocramius/PackageVersions/issues",
+                "source": "https://github.com/Ocramius/PackageVersions/tree/2.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/package-versions",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-05T18:04:57+00:00"
+        },
+        {
             "name": "ondram/ci-detector",
             "version": "3.5.1",
             "source": {
@@ -3204,12 +3193,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Pipeline\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Pipeline\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5691,12 +5680,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]

--- a/src/Domain/Entity/Event.php
+++ b/src/Domain/Entity/Event.php
@@ -13,6 +13,7 @@ namespace Eluceo\iCal\Domain\Entity;
 
 use Eluceo\iCal\Domain\ValueObject\Alarm;
 use Eluceo\iCal\Domain\ValueObject\Attachment;
+use Eluceo\iCal\Domain\ValueObject\Category;
 use Eluceo\iCal\Domain\ValueObject\Location;
 use Eluceo\iCal\Domain\ValueObject\Occurrence;
 use Eluceo\iCal\Domain\ValueObject\Organizer;
@@ -46,6 +47,11 @@ class Event
      * @var array<Attachment>
      */
     private array $attachments = [];
+
+    /**
+     * @var array<Category>
+     */
+    private array $categories = [];
 
     public function __construct(?UniqueIdentifier $uniqueIdentifier = null)
     {
@@ -282,5 +288,35 @@ class Event
     public function getAttendees(): array
     {
         return $this->attendees;
+    }
+
+    public function hasCategory(): bool
+    {
+        return !empty($this->categories);
+    }
+
+    public function addCategory(Category $category): self
+    {
+        $this->categories[] = $category;
+
+        return $this;
+    }
+
+    /**
+     * @param Category[] $categories
+     */
+    public function setCategories(array $categories): self
+    {
+        $this->categories = $categories;
+
+        return $this;
+    }
+
+    /**
+     * @return Category[]
+     */
+    public function getCategories(): array
+    {
+        return $this->categories;
     }
 }

--- a/src/Domain/Entity/Event.php
+++ b/src/Domain/Entity/Event.php
@@ -290,7 +290,7 @@ class Event
         return $this->attendees;
     }
 
-    public function hasCategory(): bool
+    public function hasCategories(): bool
     {
         return !empty($this->categories);
     }

--- a/src/Domain/ValueObject/Category.php
+++ b/src/Domain/ValueObject/Category.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the eluceo/iCal package.
+ *
+ * (c) 2022 Markus Poerschke <markus@poerschke.nrw>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Eluceo\iCal\Domain\ValueObject;
+
+final class Category
+{
+    private string $category;
+
+    public function __construct(string $category)
+    {
+        $this->category = $category;
+    }
+
+    public function __toString(): string
+    {
+        return $this->category;
+    }
+}

--- a/src/Presentation/Factory/EventFactory.php
+++ b/src/Presentation/Factory/EventFactory.php
@@ -30,6 +30,7 @@ use Eluceo\iCal\Presentation\Component\Property\Value\DateTimeValue;
 use Eluceo\iCal\Presentation\Component\Property\Value\DateValue;
 use Eluceo\iCal\Presentation\Component\Property\Value\GeoValue;
 use Eluceo\iCal\Presentation\Component\Property\Value\IntegerValue;
+use Eluceo\iCal\Presentation\Component\Property\Value\ListValue;
 use Eluceo\iCal\Presentation\Component\Property\Value\TextValue;
 use Eluceo\iCal\Presentation\Component\Property\Value\UriValue;
 use Generator;
@@ -43,8 +44,7 @@ class EventFactory
     private DateTimeFactory $dateTimeFactory;
     private AttendeeFactory $attendeeFactory;
 
-    public function __construct(?AlarmFactory $alarmFactory = null, ?DateTimeFactory $dateTimeFactory = null, ?AttendeeFactory $attendeeFactory = null)
-    {
+    public function __construct(?AlarmFactory $alarmFactory = null, ?DateTimeFactory $dateTimeFactory = null, ?AttendeeFactory $attendeeFactory = null) {
         $this->alarmFactory = $alarmFactory ?? new AlarmFactory();
         $this->dateTimeFactory = $dateTimeFactory ?? new DateTimeFactory();
         $this->attendeeFactory = $attendeeFactory ?? new AttendeeFactory();
@@ -111,6 +111,10 @@ class EventFactory
             foreach ($event->getAttendees() as $attendee) {
                 yield $this->attendeeFactory->createProperty($attendee);
             }
+        }
+
+        if ($event->hasCategory()) {
+            yield $this->getCategoryProperties($event);
         }
 
         foreach ($event->getAttachments() as $attachment) {
@@ -219,5 +223,15 @@ class EventFactory
         }
 
         return new Property('ORGANIZER', new UriValue($organizer->getEmailAddress()->toUri()), $parameters);
+    }
+
+    private function getCategoryProperties(Event $event): Property
+    {
+        $categories = [];
+        foreach ($event->getCategories() as $category) {
+            $categories[] = new TextValue((string) $category);
+        }
+
+        return new Property('CATEGORIES', new ListValue($categories));
     }
 }

--- a/src/Presentation/Factory/EventFactory.php
+++ b/src/Presentation/Factory/EventFactory.php
@@ -114,7 +114,7 @@ class EventFactory
             }
         }
 
-        if ($event->hasCategory()) {
+        if ($event->hasCategories()) {
             yield $this->getCategoryProperties($event);
         }
 

--- a/src/Presentation/Factory/EventFactory.php
+++ b/src/Presentation/Factory/EventFactory.php
@@ -44,7 +44,8 @@ class EventFactory
     private DateTimeFactory $dateTimeFactory;
     private AttendeeFactory $attendeeFactory;
 
-    public function __construct(?AlarmFactory $alarmFactory = null, ?DateTimeFactory $dateTimeFactory = null, ?AttendeeFactory $attendeeFactory = null) {
+    public function __construct(?AlarmFactory $alarmFactory = null, ?DateTimeFactory $dateTimeFactory = null, ?AttendeeFactory $attendeeFactory = null)
+    {
         $this->alarmFactory = $alarmFactory ?? new AlarmFactory();
         $this->dateTimeFactory = $dateTimeFactory ?? new DateTimeFactory();
         $this->attendeeFactory = $attendeeFactory ?? new AttendeeFactory();

--- a/tests/Unit/Presentation/Factory/EventFactoryTest.php
+++ b/tests/Unit/Presentation/Factory/EventFactoryTest.php
@@ -20,6 +20,7 @@ use Eluceo\iCal\Domain\Enum\ParticipationStatus;
 use Eluceo\iCal\Domain\Enum\RoleType;
 use Eluceo\iCal\Domain\ValueObject\Attachment;
 use Eluceo\iCal\Domain\ValueObject\BinaryContent;
+use Eluceo\iCal\Domain\ValueObject\Category;
 use Eluceo\iCal\Domain\ValueObject\Date;
 use Eluceo\iCal\Domain\ValueObject\DateTime;
 use Eluceo\iCal\Domain\ValueObject\EmailAddress;
@@ -493,6 +494,33 @@ class EventFactoryTest extends TestCase
         self::assertEventRendersCorrect($event, [
             'URL:https://example.org/calendarevent',
         ]);
+    }
+
+    public function testEventWithOneCategory()
+    {
+        $category = new Category('category');
+        $event = (new Event())->addCategory($category);
+
+        self::assertEventRendersCorrect(
+            $event,
+            [
+                'CATEGORIES:category',
+            ]
+        );
+    }
+
+    public function testEventWithMultipleCategories()
+    {
+        $event = (new Event())
+            ->addCategory(new Category('category 1'))
+            ->addCategory(new Category('category 2'));
+
+        self::assertEventRendersCorrect(
+            $event,
+            [
+                'CATEGORIES:category 1,category 2',
+            ]
+        );
     }
 
     private static function assertEventRendersCorrect(Event $event, array $expected)

--- a/website/docs/component-event.md
+++ b/website/docs/component-event.md
@@ -33,15 +33,16 @@ $event = (new Event())
 
 The following sections explain the properties of the domain object:
 
--   [Unique Identifier](#unique-identifier)
--   [Touched at](#touched-at)
--   [Summary](#summary)
--   [Description](#description)
--   [Occurrence](#occurrence)
--   [Location](#location)
--   [Organizer](#organizer)
--   [Attachments](#attachments)
--   [Attendee](#attendee)
+- [Unique Identifier](#unique-identifier)
+- [Touched at](#touched-at)
+- [Summary](#summary)
+- [Description](#description)
+- [Occurrence](#occurrence)
+- [Location](#location)
+- [Organizer](#organizer)
+- [Attachments](#attachments)
+- [Attendee](#attendee)
+- [Categories](#categories)
 
 ### Unique Identifier
 
@@ -316,4 +317,19 @@ $event = (new Event())
 $event = new Event();
 $event->addAttachment($urlAttachment);
 $event->addAttachment($binaryContentAttachment);
+```
+
+### Categories
+
+This property is used to specify categories or subtypes of the calendar component.
+The categories are useful in searching for a calendar component of a particular type and category.
+
+```php
+use Eluceo\iCal\Domain\Entity\Event;
+use Eluceo\iCal\Domain\ValueObject\Category;
+
+$event = new Event();
+$event
+    ->addCategory(new Category('APPOINTMENT'))
+    ->addCategory(new Category('EDUCATION'));
 ```

--- a/website/docs/component-event.md
+++ b/website/docs/component-event.md
@@ -33,16 +33,16 @@ $event = (new Event())
 
 The following sections explain the properties of the domain object:
 
-- [Unique Identifier](#unique-identifier)
-- [Touched at](#touched-at)
-- [Summary](#summary)
-- [Description](#description)
-- [Occurrence](#occurrence)
-- [Location](#location)
-- [Organizer](#organizer)
-- [Attachments](#attachments)
-- [Attendee](#attendee)
-- [Categories](#categories)
+-   [Unique Identifier](#unique-identifier)
+-   [Touched at](#touched-at)
+-   [Summary](#summary)
+-   [Description](#description)
+-   [Occurrence](#occurrence)
+-   [Location](#location)
+-   [Organizer](#organizer)
+-   [Attachments](#attachments)
+-   [Attendee](#attendee)
+-   [Categories](#categories)
 
 ### Unique Identifier
 

--- a/website/docs/maturity-matrix.md
+++ b/website/docs/maturity-matrix.md
@@ -34,7 +34,7 @@ See [RFC 5545 section 3.6](https://tools.ietf.org/html/rfc5545#section-3.6).
 See [RFC 5545 section 3.6.1](https://tools.ietf.org/html/rfc5545#section-3.6.1).
 
 | Property                    | Supported |
-| --------------------------- | :-------: |
+| --------------------------- |:---------:|
 | dtstamp                     |     ✔     |
 | uid                         |     ✔     |
 | dtstart                     |     ✔     |
@@ -57,7 +57,7 @@ See [RFC 5545 section 3.6.1](https://tools.ietf.org/html/rfc5545#section-3.6.1).
 | duration                    |     ✖     |
 | attach                      |     ✔     |
 | attendee                    |     ✔     |
-| categories                  |     ✖     |
+| categories                  |    (✔)    |
 | comment                     |     ✖     |
 | contact                     |     ✖     |
 | exdate                      |     ✖     |

--- a/website/docs/maturity-matrix.md
+++ b/website/docs/maturity-matrix.md
@@ -34,7 +34,7 @@ See [RFC 5545 section 3.6](https://tools.ietf.org/html/rfc5545#section-3.6).
 See [RFC 5545 section 3.6.1](https://tools.ietf.org/html/rfc5545#section-3.6.1).
 
 | Property                    | Supported |
-| --------------------------- |:---------:|
+| --------------------------- | :-------: |
 | dtstamp                     |     ✔     |
 | uid                         |     ✔     |
 | dtstart                     |     ✔     |


### PR DESCRIPTION
add possibility for categories on events: https://www.kanzaki.com/docs/ical/categories.html

This omits the possibilities of having categories available for multiple languages and having xparams (since currently, no other properties support those).

example usage:
```php
 $event = (new Event())
            ->addCategory(new Category('category 1'))
            ->addCategory(new Category('category 2'));
```