### PR TITLE
Update EmailAddress.php

### DIFF
--- a/src/Domain/ValueObject/EmailAddress.php
+++ b/src/Domain/ValueObject/EmailAddress.php
@@ -33,6 +33,6 @@ final class EmailAddress
 
     public function toUri(): Uri
     {
-        return new Uri('mailto:' . urlencode($this->emailAddress));
+        return new Uri('mailto:' . str_replace('%40', '@', urlencode($this->emailAddress)));
     }
 }


### PR DESCRIPTION
Several email/calendar clients do not support %40 in place of @ in email addresses. For example, EmClient will show "nobody@invalid.invalid" instead of the actual email address. Also some other clients may work but show the %40 in plain text instead of converting it to @, confusing users. 

So let's just not replace @ with %40. 😊

Fixes #434