### PR TITLE
Return self from Calendar.setPublishedTTL().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Support chaining of Calendar.setPublishedTTL() [#452](https://github.com/markuspoerschke/iCal/pull/452)
+
 ## [2.7.0] - 2022-06-21
 
 ### Added

--- a/src/Domain/Entity/Calendar.php
+++ b/src/Domain/Entity/Calendar.php
@@ -64,9 +64,11 @@ class Calendar
         return $this->publishedTTL;
     }
 
-    public function setPublishedTTL(?DateInterval $ttl): void
+    public function setPublishedTTL(?DateInterval $ttl): self
     {
         $this->publishedTTL = $ttl;
+
+        return $this;
     }
 
     public function getProductIdentifier(): string


### PR DESCRIPTION
This allows chaining:

```php
$cal = (new Calendar())
  ->setPublishedTTL(...)
  ->setProductIdentifier(...);
```