### PR TITLE
Fix formatting UTC date time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fix formatting date time property with UTC time zone
+
 ## [2.9.0] - 2022-12-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Fix formatting date time property with UTC time zone
+-   Fix formatting date time property with UTC time zone [#482](https://github.com/markuspoerschke/iCal/pull/482)
 
 ## [2.9.0] - 2022-12-23
 

--- a/src/Presentation/Component/Property/Value/DateTimeValue.php
+++ b/src/Presentation/Component/Property/Value/DateTimeValue.php
@@ -41,6 +41,10 @@ final class DateTimeValue extends Value
 
     private function convertDateTimeToString(DateTime $dateTime): string
     {
+        if ($dateTime->hasDateTimeZone() && $dateTime->getDateTimeZone()->getName() === 'UTC') {
+            return $dateTime->getDateTime()->format(self::FORMAT_UTC);
+        }
+
         return $dateTime->getDateTime()->format(self::FORMAT);
     }
 

--- a/src/Presentation/Factory/DateTimeFactory.php
+++ b/src/Presentation/Factory/DateTimeFactory.php
@@ -37,7 +37,11 @@ class DateTimeFactory
      */
     private function getParameters(PointInTime $pointInTime): array
     {
-        if ($pointInTime instanceof DateTime && $pointInTime->hasDateTimeZone()) {
+        if (
+            $pointInTime instanceof DateTime
+            && $pointInTime->hasDateTimeZone()
+            && $pointInTime->getDateTimeZone()->getName() !== 'UTC'
+        ) {
             return [
                 new Property\Parameter('TZID', new TextValue($pointInTime->getDateTimeZone()->getName())),
             ];

--- a/tests/Unit/Presentation/Factory/DateTimeFactoryTest.php
+++ b/tests/Unit/Presentation/Factory/DateTimeFactoryTest.php
@@ -27,4 +27,13 @@ class DateTimeFactoryTest extends TestCase
 
         self::assertSame('DTSTART;TZID=Europe/Berlin:20210122T111213', $property->__toString());
     }
+
+    public function testUtcTimeZone(): void
+    {
+        $dateTime = new DateTime(new PhpDateTimeImmutable('2022-12-25 23:29:00', new DateTimeZone('UTC')), true);
+
+        $property = (new DateTimeFactory())->createProperty('DTSTART', $dateTime);
+
+        self::assertSame('DTSTART:20221225T232900Z', $property->__toString());
+    }
 }


### PR DESCRIPTION
Rather than setting TZID=UTC, date times that are using UTC must end with the Z letter.

Wrong: DTSTART;TZID=UTC:20220812T090000
Correct: DTSTART;20220812T090000Z

Fixes: #462
Fixes: #263