### PR TITLE
[FEATURE] Enable TimeSpan with null end

### DIFF
--- a/src/Domain/ValueObject/TimeSpan.php
+++ b/src/Domain/ValueObject/TimeSpan.php
@@ -14,15 +14,15 @@ namespace Eluceo\iCal\Domain\ValueObject;
 final class TimeSpan extends Occurrence
 {
     private DateTime $begin;
-    private DateTime $end;
+    private ?DateTime $end;
 
-    public function __construct(DateTime $begin, DateTime $end)
+    public function __construct(DateTime $begin, ?DateTime $end = null)
     {
         $this->begin = $begin;
         $this->end = $end;
     }
 
-    public static function create(DateTime $begin, DateTime $end): self
+    public static function create(DateTime $begin, ?DateTime $end = null): self
     {
         return new static($begin, $end);
     }
@@ -32,7 +32,7 @@ final class TimeSpan extends Occurrence
         return $this->begin;
     }
 
-    public function getEnd(): DateTime
+    public function getEnd(): ?DateTime
     {
         return $this->end;
     }

--- a/src/Presentation/Factory/EventFactory.php
+++ b/src/Presentation/Factory/EventFactory.php
@@ -175,7 +175,9 @@ class EventFactory
 
         if ($occurrence instanceof TimeSpan) {
             yield $this->dateTimeFactory->createProperty('DTSTART', $occurrence->getBegin());
-            yield $this->dateTimeFactory->createProperty('DTEND', $occurrence->getEnd());
+            if ($occurrence->getEnd() !== null) {
+                yield $this->dateTimeFactory->createProperty('DTEND', $occurrence->getEnd());
+            }
         }
     }
 


### PR DESCRIPTION
This commit allows creating TimeSpan Object only with `DTSTART` set. As a starting time without ending is allowed in iCal definitions, this package should respect the ability having no end time set, too.

Fixes #561 