### PR TITLE
Implement some more features from RFC7986

### DIFF
--- a/src/Domain/Entity/Calendar.php
+++ b/src/Domain/Entity/Calendar.php
@@ -24,6 +24,10 @@ class Calendar
 
     private ?DateInterval $publishedTTL = null;
 
+    private ?string $calendarName = null;
+    private ?string $calendarDescription = null;
+    private ?DateInterval $refreshInterval = null;
+
     private Events $events;
 
     /**
@@ -106,6 +110,42 @@ class Calendar
     public function addTimeZone(TimeZone $timeZone): self
     {
         $this->timeZones[] = $timeZone;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->calendarName;
+    }
+
+    public function setName(?string $calendarName): self
+    {
+        $this->calendarName = $calendarName;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->calendarDescription;
+    }
+
+    public function setDescription(?string $calendarDescription): self
+    {
+        $this->calendarDescription = $calendarDescription;
+
+        return $this;
+    }
+
+    public function getRefreshInterval(): ?DateInterval
+    {
+        return $this->refreshInterval;
+    }
+
+    public function setRefreshInterval(?DateInterval $refreshInterval)
+    {
+        $this->refreshInterval = $refreshInterval;
 
         return $this;
     }

--- a/src/Presentation/Factory/CalendarFactory.php
+++ b/src/Presentation/Factory/CalendarFactory.php
@@ -62,5 +62,16 @@ class CalendarFactory
             /* @see http://msdn.microsoft.com/en-us/library/ee178699(v=exchg.80).aspx */
             yield new Property('X-PUBLISHED-TTL', new DurationValue($publishedTTL));
         }
+        if ($calendar->getCalendarName() !== null) {
+            yield new Property('NAME', new TextValue($calendar->getCalendarName()));
+            yield new Property('X-WR-CALNAME', new TextValue($calendar->getCalendarName()));
+        }
+        if ($calendar->getCalendarDescription() !== null) {
+            yield new Property('DESCRIPTION', new TextValue($calendar->getCalendarDescription()));
+            yield new Property('X-WR-CALDESC', new TextValue($calendar->getCalendarDescription()));
+        }
+        if ($calendar->getRefreshInterval() !== null) {
+            yield new Property("REFRESH-INTERVAL", new DurationValue($calendar->getRefreshInterval()));
+        }
     }
 }

--- a/src/Presentation/Factory/CalendarFactory.php
+++ b/src/Presentation/Factory/CalendarFactory.php
@@ -71,7 +71,7 @@ class CalendarFactory
             yield new Property('X-WR-CALDESC', new TextValue($calendar->getCalendarDescription()));
         }
         if ($calendar->getRefreshInterval() !== null) {
-            yield new Property("REFRESH-INTERVAL", new DurationValue($calendar->getRefreshInterval()));
+            yield new Property('REFRESH-INTERVAL', new DurationValue($calendar->getRefreshInterval()));
         }
     }
 }

--- a/tests/Unit/Domain/Entity/CalendarTest.php
+++ b/tests/Unit/Domain/Entity/CalendarTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class CalendarTest extends TestCase
 {
-    public function provideGetSetPublishedTTLTestData(): array
+    public function provideDateIntervalTestData(): array
     {
         return [
             [new DateInterval('P1W')],
@@ -26,7 +26,7 @@ class CalendarTest extends TestCase
     }
 
     /**
-     * @dataProvider provideGetSetPublishedTTLTestData
+     * @dataProvider provideDateIntervalTestData
      *
      * @covers \Eluceo\iCal\Domain\Entity\Calendar::getPublishedTTL
      * @covers \Eluceo\iCal\Domain\Entity\Calendar::setPublishedTTL
@@ -38,5 +38,20 @@ class CalendarTest extends TestCase
         $calendar = new Calendar();
         $calendar->setPublishedTTL($ttl);
         self::assertSame($calendar->getPublishedTTL(), $ttl);
+    }
+
+    /**
+     * @dataProvider provideDateIntervalTestData
+     *
+     * @covers \Eluceo\iCal\Domain\Entity\Calendar::getRefreshInterval
+     * @covers \Eluceo\iCal\Domain\Entity\Calendar::setRefreshInterval
+     *
+     * @param ?DateInterval $ttl
+     */
+    public function testGetSetRefreshInterval($ttl): void
+    {
+        $calendar = new Calendar();
+        $calendar->setRefreshInterval($ttl);
+        self::assertSame($calendar->getRefreshInterval(), $ttl);
     }
 }

--- a/website/docs/component-calendar.md
+++ b/website/docs/component-calendar.md
@@ -82,5 +82,5 @@ $calendar
     ->setRefreshInterval(DateInterval::createFromDateString('1 day'));
 ```
 
-Please note that since they have been introduced rather recently ([RFC7986](https://datatracker.ietf.org/doc/html/rfc7986#page-9)), 
+Please note that since they have been introduced rather recently ([RFC7986](https://datatracker.ietf.org/doc/html/rfc7986#page-9)),
 they might not be supported in your calendar app.

--- a/website/docs/component-calendar.md
+++ b/website/docs/component-calendar.md
@@ -62,3 +62,25 @@ $calendar
     ->addTimeZone(TimeZone::createFromPhpDateTimeZone(new PhpDateTimeZone('Europe/London')))
 ;
 ```
+
+## Other Calendar properties
+
+There are other properties on the calendar that you can set:
+
+```php
+
+
+use Eluceo\iCal\Domain\Entity\Calendar;
+use Eluceo\iCal\Domain\Entity\TimeZone;
+use DateTimeZone as PhpDateTimeZone;
+
+$calendar = new Calendar();
+$calendar
+    ->setProductIdentifier('-//eluceo/ical//2.0/EN')
+    ->setName('Our test calendar')
+    ->setDescription('This is a test calendar you can import into your calendar app.')
+    ->setRefreshInterval(DateInterval::createFromDateString('1 day'));
+```
+
+Please note that since they have been introduced rather recently ([RFC7986](https://datatracker.ietf.org/doc/html/rfc7986#page-9)), 
+they might not be supported in your calendar app.


### PR DESCRIPTION
The [RFC7986](https://datatracker.ietf.org/doc/html/rfc7986) introduced a few additional properties that I consider essential enough to warrant an implementation on the library level, rather than having them implemented by everyone using the quite verbose way via custom calendar factories.

The implemented ones are:

- NAME,
- DESCRIPTION,
- REFRESH-INTERVAL