### PR TITLE
Fix `\n` being escaped to `\\n`, leading to no newlines in actual text

### DIFF
--- a/src/Presentation/Component/Property/Value/TextValue.php
+++ b/src/Presentation/Component/Property/Value/TextValue.php
@@ -26,6 +26,7 @@ class TextValue extends Value
         ';' => '\\;',
         ',' => '\\,',
         "\n" => '\\n',
+        '\\\\n' => '\\n',
     ];
 
     /**


### PR DESCRIPTION
If a newline is included in a text field, such as the description, the backslash in `\n` is first doubled by the parser (so converted to `\\n`), then the `\n` is parsed. This results in `\\n` being included in the final ICS export, which is shown in calendar tools as `\n` instead of a newline. This PR fixes that, to make sure an intentional `\n` in the input is also exported as a newline.