### PR TITLE
Add property 'method' as defined in RFC-5545.

### DIFF
--- a/src/Domain/Entity/Event.php
+++ b/src/Domain/Entity/Event.php
@@ -12,6 +12,7 @@
 namespace Eluceo\iCal\Domain\Entity;
 
 use Eluceo\iCal\Domain\Enum\EventStatus;
+use Eluceo\iCal\Domain\Enum\Method;
 use Eluceo\iCal\Domain\ValueObject\Alarm;
 use Eluceo\iCal\Domain\ValueObject\Attachment;
 use Eluceo\iCal\Domain\ValueObject\Category;
@@ -34,6 +35,7 @@ class Event
     private ?Organizer $organizer = null;
     private ?Timestamp $lastModified = null;
     private ?EventStatus $status = null;
+    private ?Method $method = null;
 
     /**
      * @var array<Attendee>
@@ -344,6 +346,25 @@ class Event
     public function unsetStatus(): self
     {
         $this->status = null;
+
+        return $this;
+    }
+
+    public function getMethod(): Method
+    {
+        assert($this->method !== null);
+
+        return $this->method;
+    }
+
+    public function hasMethod(): bool
+    {
+        return $this->method !== null;
+    }
+
+    public function setMethod(Method $method): self
+    {
+        $this->method = $method;
 
         return $this;
     }

--- a/src/Domain/Enum/Method.php
+++ b/src/Domain/Enum/Method.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Eluceo\iCal\Domain\Enum;
+
+final class Method
+{
+    private static ?self $request = null;
+    private static ?self $publish = null;
+
+    public static function REQUEST(): self
+    {
+        return self::$request ??= new self();
+    }
+
+    public static function PUBLISH(): self
+    {
+        return self::$publish ??= new self();
+    }
+}

--- a/src/Presentation/Factory/EventFactory.php
+++ b/src/Presentation/Factory/EventFactory.php
@@ -15,6 +15,7 @@ use DateInterval;
 use Eluceo\iCal\Domain\Collection\Events;
 use Eluceo\iCal\Domain\Entity\Event;
 use Eluceo\iCal\Domain\Enum\EventStatus;
+use Eluceo\iCal\Domain\Enum\Method;
 use Eluceo\iCal\Domain\ValueObject\Alarm;
 use Eluceo\iCal\Domain\ValueObject\Attachment;
 use Eluceo\iCal\Domain\ValueObject\MultiDay;
@@ -123,6 +124,10 @@ class EventFactory
 
         if ($event->hasStatus()) {
             yield new Property('STATUS', $this->getEventStatusTextValue($event->getStatus()));
+        }
+
+        if ($event->hasMethod()) {
+            yield new Property('METHOD', $this->getMethodTextValue($event->getMethod()));
         }
 
         foreach ($event->getAttachments() as $attachment) {
@@ -277,5 +282,18 @@ class EventFactory
         }
 
         throw new UnexpectedValueException(sprintf('The enum %s resulted into an unknown status type value that is not yet implemented.', EventStatus::class));
+    }
+
+    private function getMethodTextValue(Method $method): TextValue
+    {
+        if ($method === Method::PUBLISH()) {
+            return new TextValue('PUBLISH');
+        }
+
+        if ($method === Method::REQUEST()) {
+            return new TextValue('REQUEST');
+        }
+
+        throw new UnexpectedValueException(sprintf('The enum %s resulted into an unknown method type value that is not yet implemented.', Method::class));
     }
 }


### PR DESCRIPTION
This commit allows adding the property 'method' to an event. 

Fixes #191 