### PR TITLE
Fix PHP 8.4 deprecation - implicitly marking parameter as nullable is deprecated #678

### DIFF
--- a/src/Domain/Entity/Event.php
+++ b/src/Domain/Entity/Event.php
@@ -24,7 +24,7 @@ use Eluceo\iCal\Domain\ValueObject\Uri;
 
 class Event
 {
-    private UniqueIdentifier $uniqueIdentifier;
+    private ?UniqueIdentifier $uniqueIdentifier = null;
     private Timestamp $touchedAt;
     private ?string $summary = null;
     private ?string $description = null;


### PR DESCRIPTION
Issue: https://github.com/markuspoerschke/iCal/issues/678