### PR TITLE
[0.x] Fix deprecation issues on PHP 8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"

--- a/src/Component/Event.php
+++ b/src/Component/Event.php
@@ -236,7 +236,7 @@ class Event extends Component
      */
     protected $attachments = [];
 
-    public function __construct(string $uniqueId = null)
+    public function __construct(?string $uniqueId = null)
     {
         if (null == $uniqueId) {
             $uniqueId = uniqid();

--- a/src/Property/DateTimeProperty.php
+++ b/src/Property/DateTimeProperty.php
@@ -26,7 +26,7 @@ class DateTimeProperty extends Property
      */
     public function __construct(
         $name,
-        \DateTimeInterface $dateTime = null,
+        ?\DateTimeInterface $dateTime = null,
         $noTime = false,
         $useTimezone = false,
         $useUtc = false,

--- a/src/Property/Event/RecurrenceId.php
+++ b/src/Property/Event/RecurrenceId.php
@@ -44,7 +44,7 @@ class RecurrenceId extends Property
      */
     protected $range;
 
-    public function __construct(\DateTimeInterface $dateTime = null)
+    public function __construct(?\DateTimeInterface $dateTime = null)
     {
         $this->name = 'RECURRENCE-ID';
         $this->parameterBag = new ParameterBag();

--- a/src/Property/Event/RecurrenceRule.php
+++ b/src/Property/Event/RecurrenceRule.php
@@ -209,7 +209,7 @@ class RecurrenceRule implements ValueInterface
     /**
      * @return $this
      */
-    public function setUntil(\DateTimeInterface $until = null)
+    public function setUntil(?\DateTimeInterface $until = null)
     {
         $this->until = $until;
 

--- a/src/Util/DateUtil.php
+++ b/src/Util/DateUtil.php
@@ -13,7 +13,7 @@ namespace Eluceo\iCal\Util;
 
 class DateUtil
 {
-    public static function getDefaultParams(\DateTimeInterface $dateTime = null, $noTime = false, $useTimezone = false, $timezoneString = '')
+    public static function getDefaultParams(?\DateTimeInterface $dateTime = null, $noTime = false, $useTimezone = false, $timezoneString = '')
     {
         $params = [];
 
@@ -39,7 +39,7 @@ class DateUtil
      *
      * @return mixed
      */
-    public static function getDateString(\DateTimeInterface $dateTime = null, $noTime = false, $useTimezone = false, $useUtc = false)
+    public static function getDateString(?\DateTimeInterface $dateTime = null, $noTime = false, $useTimezone = false, $useUtc = false)
     {
         if (empty($dateTime)) {
             $dateTime = new \DateTimeImmutable();


### PR DESCRIPTION
example:
```
Implicitly marking parameter $uniqueId as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eluceo/ical/src/Component/Event.php on line 239
```